### PR TITLE
Issue #15: Add selectbox to switch between assignment views

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,14 @@ Each cabin is assigned to one fleet for the week.
 
 A mapping of a camper to a seatrade in a specific block. Each camper gets exactly 2 assignments per week (one per block).
 
+### AssignmentSolution
+
+The resolved output of solving a seatrade scheduling problem. Produced by wrangling the solver's raw binary decision variables into a long-form DataFrame with columns: camper, seatrade, block, preference, cabin, assignment. Owned by the core package, not the problem builder or the UI.
+
+### SolverStatus
+
+Tracks the state of an in-progress or completed solve. Fields: percent, message, state (running/complete/error). Owned by the service layer, read by the UI via `@st.fragment` polling. Currently reports infeasibility as a message only; future work to add structured constraint-conflict diagnostics.
+
 ### Assignment Export
 
 The app exports assignments in 3 formats for different audiences:
@@ -68,44 +76,39 @@ Each export includes columns: camper, seatrade, assignment (0/1), preference (1-
 
 ```mermaid
 flowchart LR
-    subgraph User_Input [User Input Layer]
-        UI[Streamlit UI]
+    subgraph UI [app/ — Presentation Layer]
+        Upload[File Upload / Simulation Forms]
+        Fragment["@st.fragment polling SolverStatus"]
+        Display[Render AssignmentSolution + Charts]
     end
-    
-    subgraph State_Layer [Session State]
-        direction TB
-        S1[seatrade_simulation_config]
-        S2[camper_simulation_config]
-        S3[optimization_config]
+
+    subgraph Service [seatrades/ — Service Layer]
+        Sim[simulation.py: Generate Mock Data]
+        Val[preferences.py: Validate Inputs]
+        Prob[SchedulingProblem: Build MILP]
+        Solve[solver.py: Solve + SolverStatus]
+        Result[results.py: AssignmentSolution]
     end
-    
-    subgraph Solver_Layer [Optimization Engine]
-        SA[Seatrades.assign]
-        PULP[PuLP Solver]
-    end
-    
-    subgraph Output_Layer [Output]
-        DF[(Assignments DataFrame)]
-        Display[Assignments Tab Display]
-    end
-    
-    UI --> State_Layer
-    State_Layer -->|preferences| SA
-    SA -->|MILP Problem| PULP
-    PULP -->|solution| DF
-    DF --> Display
-    
-    classDef userInput fill:#e1f5fe,stroke:#0277bd,stroke-width:2px,shape:sloped-rectangle;
-    classDef state fill:#fff3e0,stroke:#ef6c00,stroke-width:2px,shape:cylinder;
-    classDef process fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px;
-    classDef solver fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px,shape:subprocess;
-    classDef output fill:#fce4ec,stroke:#c2185b,stroke-width:2px,shape:display;
-    
-    class UI userInput;
-    class S1,S2,S3 state;
-    class SA process;
-    class PULP solver;
-    class DF,Display output;
+
+    Upload --> Sim
+    Sim --> Val
+    Val --> Prob
+    Prob -->|pulp.LpProblem| Solve
+    Solve -->|AssignmentSolution| Result
+    Solve -->|SolverStatus| Fragment
+    Result --> Display
+```
+
+### Pipeline (happy path)
+
+```
+1. User uploads CSVs or uses simulation → app/ calls seatrades.simulation
+2. Input DataFrames validated → seatrades.preferences (Pandera + cross-ref)
+3. SchedulingProblem(prefs, config) → holds parsed state
+4. problem.build() → pulp.LpProblem
+5. solver.run(problem, config) → AssignmentSolution + SolverStatus
+6. UI reads SolverStatus via @st.fragment, displays AssignmentSolution
+7. AssignmentSolution.export(view="camper"|"cabin"|"seatrade") → formatted DataFrame
 ```
 
 ## Optimization Problem
@@ -121,9 +124,66 @@ The scheduler solves a mixed-integer linear programming problem with these const
 7. **Fleet balance** - Cabins split evenly between fleets
 8. **Gender balance** - Boys/girls cabins split evenly between fleets
 
+## Module Boundaries
+
+| Package | Responsibility |
+|---------|---------------|
+| `seatrades/` | Service layer — domain logic, optimization, simulation, results |
+| `app/` | Presentation layer — Streamlit UI only, no business logic (rename from `seatrades_app/`) |
+
+### app/ modules
+
+| Module | Owns |
+|--------|------|
+| `app.py` | Entry point, tab layout |
+| `state.py` | Constants for all session state keys (low priority, replace scattered strings) |
+| `tabs/` | Thin Streamlit presentation — widgets, forms, file uploads. Call service functions, display results. |
+
+### seatrades/ modules
+
+| Module | Owns |
+|--------|------|
+| `scheduling_problem.py` | `SchedulingProblem` — holds parsed domain state, builds MILP (variables, constraints, objective). Does NOT solve. |
+| `solver.py` | Orchestrate solve, track progress (`SolverStatus`), background thread |
+| `results.py` | `AssignmentSolution` — wrangle + export views |
+| `visualization.py` | Build `alt.Chart` specs from `AssignmentSolution`. No Streamlit dependency — renders in any Altair-capable frontend. |
+| `preferences.py` | Pandera schemas + cross-reference validation (e.g., camper prefs must name seatrades that exist) |
+| `simulation.py` | Generate mock camper + seatrade data |
+| `config.py` | `OptimizationConfig`, `CamperSimulationConfig`, `SeatradeSimulationConfig` |
+
+## Architecture Grilling — Decisions Log
+
+Resolved during grilling session 2026-05-05. Open questions marked with [OPEN].
+
+1. **`Seatrades` class → split into SchedulingProblem + solver + results.** Problem builder owns variables/constraints/objective. Solving is separate. Wrangling is separate. `SchedulingProblem` is stateful (holds parsed domain state) because the wrangler needs the same state — avoids re-parsing or building a second context object.
+
+2. **Solver produces `AssignmentSolution`, not raw pulp object.** Clean boundary: problem goes in, solution comes out. No leaking PuLP internals.
+
+3. **Service function `solver.run(problem, config) -> AssignmentSolution + SolverStatus`.** UI calls one function. No solver orchestration in the presentation layer.
+
+4. **Solver monitoring splits: service layer runs solver + reads CBC log, UI polls `SolverStatus` via `@st.fragment`.** PuLP/CBC doesn't support mid-solve callbacks — log file is the only progress signal. `@st.fragment(run_every=...)` replaces manual `while`+`sleep` polling.
+
+5. **Simulation data generation moves to service layer** (`seatrades/simulation.py`). It's domain logic, not UI.
+
+6. **Cross-reference validation moves to service layer** (`seatrades/preferences.py`). Dynamic Pandera subclass generation for checking camper prefs against available seatrades becomes a function that takes `available_seatrades` as a parameter.
+
+7. **Config dataclasses move to service layer** (`seatrades/config.py`). `OptimizationConfig`, `CamperSimulationConfig`, `SeatradeSimulationConfig` don't belong in UI files.
+
+8. **Infeasibility: report only for now (A), diagnose later (B).** `SolverStatus` reports error state + message. Structured constraint-conflict diagnostics are future work.
+
+9. **Session state keys: centralize in `app/state.py`** (low priority). Replaces scattered string literals for IDE support and typo protection.
+
+10. **Rename `seatrades_app/` → `app/`**. Follows Streamlit convention, avoids naming confusion with `seatrades/` service package.
+
+11. **Altair chart → separate `seatrades/visualization.py` module.** Chart is neither presentation layer nor data model — it's a visualization spec that consumes `AssignmentSolution`. Stays in service layer (no Streamlit dep) so it's reusable outside the app (API, notebooks, other frontends). `results.py` stays clean: data model + export only. `app/` renders via `st.altair_chart()`.
+
 ## Tech Stack
 
 - **UI:** Streamlit
 - **Optimizer:** PuLP (mixed-integer linear programming)
 - **Validation:** Pandera (DataFrame schemas)
 - **Deployment:** Streamlit Cloud
+
+## Git Workflow
+
+Three branch prefixes: `feature/` (PRD or standalone feature), `dev/` (issue within a PRD), `fix/` (bug fix off main). All merges are squash-merge via PR. PRD branches are long-lived staging areas for QA. See [ADR 0005](docs/adr/0005-git-branching-strategy.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,11 +1,53 @@
 # Contributing to SeaTrades
 
+## Branching Strategy
+
+SeaTrades uses a tiered branching strategy. See [ADR 0005](docs/adr/0005-git-branching-strategy.md) for the full rationale.
+
+### Branch types
+
+| Type | Prefix | Source | Merges into | Purpose |
+|---|---|---|---|---|
+| PRD / large feature | `feature/13-csv-import` | `main` | `main` | Long-lived: stages QA for a full PRD |
+| Issue (part of PRD) | `dev/42-csv-upload` | Parent `feature/` | Parent `feature/` | Short-lived: one issue, one PR |
+| Standalone feature | `feature/55-add-thing` | `main` | `main` | Short-lived: independent feature |
+| Bug fix | `fix/56-header-crash` | `main` | `main` | Short-lived: bug fix |
+
+### Merge rules
+
+- **All merges use squash merge** — one clean commit per unit of work.
+- **All merges require a PR** — for traceability and auto-closing issues.
+- `dev/` → `feature/`: self-merge (no approval needed on PRD branches).
+- `feature/` → `main`: requires approval (branch protection).
+- `fix/` → `main`: requires approval (branch protection).
+
+### Syncing long-lived branches
+
+When `main` moves ahead of a `feature/` branch, merge `main` into the `feature/` branch (do not rebase). This preserves history for any `dev/` branches based on it.
+
+### Branch cleanup
+
+- Delete remote branches after merge.
+- Keep local branches until manually cleaned up.
+
+### Example workflow
+
+```
+main
+ └── feature/13-csv-import          ← PRD branch (long-lived)
+       ├── dev/42-csv-upload         ← issue branch, PR → feature/13
+       ├── dev/43-csv-validation     ← issue branch, PR → feature/13
+       └── dev/51-csv-error-handling ← added during QA, PR → feature/13
+       (QA complete)
+ └── feature/13-csv-import PR → main (squash merge, approval required)
+```
+
 ## Development Workflow
 
-1. Create a feature branch for your work
-2. Make commits with clear messages
-3. Create a PR when ready for review
-4. Gavin reviews and merges in GitHub UI
+1. Create a branch with the right prefix (`feature/`, `dev/`, or `fix/`).
+2. Make commits with clear messages.
+3. Open a PR targeting the correct branch (`main` for `feature/` and `fix/`, parent `feature/` for `dev/`).
+4. Gavin reviews and merges in GitHub UI.
 
 ## Git / GitHub Setup
 
@@ -36,6 +78,7 @@ Since credentials are shared, Gavin must manually review and merge in GitHub UI:
 - Default to no comments — let code be self-documenting
 - Small, focused commits
 - Follow existing patterns in the codebase
+- No AAA phase labels in tests (`# Arrange`, `# Act`, `# Assert`) — the structure is implied by the code. Test names should make the scenario clear; if something needs explaining, put it in the docstring, not a phase comment.
 
 ## Testing
 

--- a/docs/adr/0003-service-layer-architecture.md
+++ b/docs/adr/0003-service-layer-architecture.md
@@ -1,0 +1,20 @@
+# Service layer between UI and optimizer
+
+The application splits into two packages: `seatrades/` (service layer — domain logic, optimization, simulation, results) and `app/` (presentation layer — Streamlit UI only). The UI calls service functions and never contains business logic, solver orchestration, or data generation.
+
+**Status: accepted**
+
+## Considered Options
+
+1. **Service layer** — A thin service function (`solver.run(problem, config) -> AssignmentSolution + SolverStatus`) sits between the UI and the optimizer. The UI calls one function; all orchestration happens in the service layer.
+
+2. **Ad-hoc** — The UI constructs `SchedulingProblem`, calls `.solve()` on the problem object, passes raw output to a wrangler, gets back results. No service layer.
+
+We chose option 1 because the solver orchestration (build → solve → wrangle) is a workflow, not a UI concern. A service function gives one place to test the full pipeline without Streamlit and one clean seam for the UI to call. Option 2 keeps solver logic tangled in `assignments_tab.py`, which already has 300 lines mixing thread management, log parsing, and progress display.
+
+## Consequences
+
+- Simulation data generation, validation, and config dataclasses move out of tab files into `seatrades/simulation.py`, `seatrades/preferences.py`, and `seatrades/config.py`.
+- Cross-tab coupling (`_clear_optimization_results` imported across tabs) disappears — state management moves to session state keys via `app/state.py`.
+- The `Seatrades` class (426 lines, monolith) splits into `SchedulingProblem` (stateful problem builder), `solver.py` (orchestration), and `results.py` (wrangling + export views).
+- `seatrades_app/` renames to `app/` following Streamlit convention.

--- a/docs/adr/0004-solver-monitoring-strategy.md
+++ b/docs/adr/0004-solver-monitoring-strategy.md
@@ -1,0 +1,27 @@
+# Solver monitoring: log-polling with Streamlit fragments
+
+The solver runs in a background thread. Progress is reported by reading the CBC log file and surfacing structured status to the UI via `@st.fragment` polling.
+
+**Status: accepted**
+
+## Why not callbacks?
+
+PuLP's `.solve()` is a blocking call to CBC. The solver writes progress to a log file — that is the only progress signal. There is no API for mid-solve callbacks or progress hooks. A callback-based approach (`on_progress(percent)`) would only fire before and after the solve, not during.
+
+## Why `@st.fragment`?
+
+The current implementation uses a manual `while` loop with `time.sleep(2)`, a `queue.Queue` for status, and regex parsing of the log file — all inside `assignments_tab.py`. `@st.fragment(run_every=timedelta(seconds=2))` is Streamlit's built-in mechanism for periodic UI updates. It replaces the manual polling loop and keeps the UI responsive without blocking the main script.
+
+## Architecture
+
+The monitoring splits into two layers:
+
+1. **Service layer** (`solver.py`) — runs the solver in a background thread, reads the CBC log, writes structured progress to a `SolverStatus` object (percent, message, state). No Streamlit imports.
+2. **UI layer** (`app/tabs/`) — `@st.fragment` reads `SolverStatus` from session state and renders progress widgets. Never touches the log file or manages threads.
+
+## Consequences
+
+- The UI never imports `threading`, `queue`, or reads log files directly.
+- `SolverStatus` is a plain dataclass with no Streamlit dependency — testable without the UI.
+- Log-parsing regex and thread management move from `assignments_tab.py` to `solver.py`.
+- Future: if a solver with callback support replaces PuLP, the service layer can switch to callbacks without changing the UI layer.

--- a/docs/adr/0005-git-branching-strategy.md
+++ b/docs/adr/0005-git-branching-strategy.md
@@ -1,0 +1,55 @@
+# ADR 0005: Git Branching Strategy
+
+**Date:** 2026-05-06
+**Status:** Accepted
+
+## Context
+
+SeaTrades uses a shared GitHub account (`gavingro`) with branch protection on `main` (PR + 1 approval). Work is tracked as GitHub issues. Some features are large (PRD-level) and need QA as a coherent whole before merging to main. Previously, all branches were flat off main with no hierarchy.
+
+## Decision
+
+Adopt a tiered branching strategy with three branch prefixes:
+
+| Branch type | Prefix | Source | Merges into | Lifecycle |
+|---|---|---|---|---|
+| PRD / large feature | `feature/13-csv-import` | `main` | `main` | Long-lived until QA complete |
+| Issue (part of PRD) | `dev/42-csv-upload` | Parent `feature/` branch | Parent `feature/` branch | Short-lived |
+| Standalone feature | `feature/55-add-thing` | `main` | `main` | Short-lived |
+| Bug fix | `fix/56-header-crash` | `main` | `main` | Short-lived |
+
+### Merge strategy
+
+- **All merges use squash merge** — one clean commit per issue on the PRD branch, one clean commit per PRD on main.
+- **All merges require a PR** — for traceability and auto-closing issues via GitHub keywords.
+- **`dev/` → `feature/`**: PR created, self-merged (no approval required).
+- **`feature/` → `main`**: PR created, requires approval (existing branch protection).
+- **`fix/` → `main`**: PR created, requires approval (same as any merge to main).
+
+### Syncing
+
+Long-lived `feature/` branches stay current by **merging `main` into `feature/`** (not rebasing). This preserves history and avoids breaking any `dev/` branches based on the feature branch.
+
+### Branch cleanup
+
+- Delete remote branches after merge.
+- Keep local branches around until manually cleaned up.
+
+### PRD tracking
+
+PRDs are tracked as GitHub issues. No milestones for now.
+
+## Consequences
+
+### Positive
+
+- QA can validate a full feature before it reaches main.
+- New issues discovered during QA can be added to the PRD branch mid-flight.
+- One commit per issue on PRD branches keeps history readable.
+- PRs auto-close issues, keeping the tracker current.
+
+### Negative
+
+- Long-lived feature branches can drift from main and require merge commits to sync.
+- More branch management overhead than trunk-based development.
+- Squash-merge loses granular commit history (preserved in closed PRs on GitHub).

--- a/seatrades_app/tabs/assignments_tab.py
+++ b/seatrades_app/tabs/assignments_tab.py
@@ -266,7 +266,6 @@ def get_view_selection(selection: str = "Captain's Book") -> Literal["camper", "
     ----------
     selection : str
         One of: "Captain's Book", "Cabin Leaders", "Seatrade Leaders".
-        Default: "Captain's Book".
 
     Returns
     -------

--- a/seatrades_app/tabs/assignments_tab.py
+++ b/seatrades_app/tabs/assignments_tab.py
@@ -48,7 +48,6 @@ class AssignmentsTab:
                 )
                 st.altair_chart(results_chart)
 
-                # Display 3 dataframe views
                 seatrades_obj = st.session_state["assigned_seatrades"]
                 df = seatrades_obj.wrangle_assignments_to_longform(
                     seatrades_obj.assignments
@@ -58,7 +57,7 @@ class AssignmentsTab:
                 st.subheader("Assignment Data")
 
                 # Selectbox to switch between views
-                view_options = ["Captain's Book", "Cabin Leaders", "Seatrade Leaders"]
+                view_options = ["camper", "cabin", "seatrade"]
                 selected_view = st.selectbox(
                     "View",
                     options=view_options,
@@ -67,7 +66,7 @@ class AssignmentsTab:
                 )
 
                 # Render selected view
-                assignment_df = render_view(df, selected_view)
+                assignment_df = prepare_assignment_view(df, selected_view)
                 st.dataframe(assignment_df)
 
 
@@ -282,28 +281,8 @@ def get_view_selection(selection: str = "Captain's Book") -> Literal["camper", "
     return mapping.get(selection, "camper")
 
 
-def render_view(df: pd.DataFrame, selection: str) -> pd.DataFrame:
-    """
-    Render assignment dataframe view based on selectbox selection.
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        Longform assignments dataframe.
-    selection : str
-        One of: "Captain's Book", "Cabin Leaders", "Seatrade Leaders".
-
-    Returns
-    -------
-    pd.DataFrame
-        Filtered, sorted, and re-ordered dataframe for display.
-    """
-    view = get_view_selection(selection)
-    return prepare_assignment_view(df, view)
-
-
 def prepare_assignment_view(
-    df: pd.DataFrame, view: Literal["camper", "cabin", "seatrade"]
+    df: pd.DataFrame, view: str
 ) -> pd.DataFrame:
     """
     Prepare an assignment dataframe view with specified sorting and column order.

--- a/seatrades_app/tabs/assignments_tab.py
+++ b/seatrades_app/tabs/assignments_tab.py
@@ -57,16 +57,16 @@ class AssignmentsTab:
                 st.subheader("Assignment Data")
 
                 # Selectbox to switch between views
-                view_options = ["camper", "cabin", "seatrade"]
+                view_options = ["Captain's Book", "Cabin Leaders", "Seatrade Leaders"]
                 selected_view = st.selectbox(
                     "View",
                     options=view_options,
-                    index=0,  # Default: Captain's Book
+                    index=0,
                     key="assignment_view_selector",
                 )
 
                 # Render selected view
-                assignment_df = prepare_assignment_view(df, selected_view)
+                assignment_df = render_view(df, selected_view)
                 st.dataframe(assignment_df)
 
 
@@ -281,8 +281,28 @@ def get_view_selection(selection: str = "Captain's Book") -> Literal["camper", "
     return mapping.get(selection, "camper")
 
 
+def render_view(df: pd.DataFrame, selection: str) -> pd.DataFrame:
+    """
+    Render a view of the assignment dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Longform assignments dataframe.
+    selection : str
+        Selectbox label: "Captain's Book", "Cabin Leaders", or "Seatrade Leaders".
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered, sorted, and re-ordered dataframe for display.
+    """
+    view = get_view_selection(selection)
+    return prepare_assignment_view(df, view)
+
+
 def prepare_assignment_view(
-    df: pd.DataFrame, view: str
+    df: pd.DataFrame, view: Literal["camper", "cabin", "seatrade"]
 ) -> pd.DataFrame:
     """
     Prepare an assignment dataframe view with specified sorting and column order.

--- a/seatrades_app/tabs/assignments_tab.py
+++ b/seatrades_app/tabs/assignments_tab.py
@@ -57,17 +57,18 @@ class AssignmentsTab:
                 st.divider()
                 st.subheader("Assignment Data")
 
-                st.markdown("### By Camper")
-                captains_book = prepare_assignment_view(df, view="camper")
-                st.dataframe(captains_book)
+                # Selectbox to switch between views
+                view_options = ["Captain's Book", "Cabin Leaders", "Seatrade Leaders"]
+                selected_view = st.selectbox(
+                    "View",
+                    options=view_options,
+                    index=0,  # Default: Captain's Book
+                    key="assignment_view_selector",
+                )
 
-                st.markdown("### By Cabin")
-                cabin_leaders = prepare_assignment_view(df, view="cabin")
-                st.dataframe(cabin_leaders)
-
-                st.markdown("### By Seatrade")
-                seatrade_leaders = prepare_assignment_view(df, view="seatrade")
-                st.dataframe(seatrade_leaders)
+                # Render selected view
+                assignment_df = render_view(df, selected_view)
+                st.dataframe(assignment_df)
 
 
 @st.dialog("Welcome to the Keats Seatrade Scheduler", width="large")
@@ -257,6 +258,49 @@ def _run_assignment_and_capture_logs(
     except Exception as e:
         print(f"Error: {e}")
         status_queue.put(-1)
+
+def get_view_selection(selection: str = "Captain's Book") -> Literal["camper", "cabin", "seatrade"]:
+    """
+    Convert selectbox label to view name.
+
+    Parameters
+    ----------
+    selection : str
+        One of: "Captain's Book", "Cabin Leaders", "Seatrade Leaders".
+        Default: "Captain's Book".
+
+    Returns
+    -------
+    Literal["camper", "cabin", "seatrade"]
+        View name for prepare_assignment_view().
+    """
+    mapping = {
+        "Captain's Book": "camper",
+        "Cabin Leaders": "cabin",
+        "Seatrade Leaders": "seatrade",
+    }
+    return mapping.get(selection, "camper")
+
+
+def render_view(df: pd.DataFrame, selection: str) -> pd.DataFrame:
+    """
+    Render assignment dataframe view based on selectbox selection.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Longform assignments dataframe.
+    selection : str
+        One of: "Captain's Book", "Cabin Leaders", "Seatrade Leaders".
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered, sorted, and re-ordered dataframe for display.
+    """
+    view = get_view_selection(selection)
+    return prepare_assignment_view(df, view)
+
 
 def prepare_assignment_view(
     df: pd.DataFrame, view: Literal["camper", "cabin", "seatrade"]

--- a/tests/test_seatrades_app/test_assignments_tab.py
+++ b/tests/test_seatrades_app/test_assignments_tab.py
@@ -5,11 +5,8 @@ from seatrades_app.tabs.assignments_tab import prepare_assignment_view
 
 class TestAssignmentView:
     def test_filters_unassigned_rows(self, sample_mixed_assignment_df):
-        """Should filter out rows where assignment == 0."""
-        # Act
         result = prepare_assignment_view(sample_mixed_assignment_df, view="camper")
 
-        # Assert: Only Alice and Carol (assigned campers)
         assert len(result) == 2
         assert result["camper"].tolist() == ["Alice", "Carol"]
         assert "assignment" not in result.columns
@@ -18,91 +15,66 @@ class TestAssignmentView:
         """Default view selection should be Captain's Book."""
         from seatrades_app.tabs.assignments_tab import get_view_selection
 
-        # Act
         view = get_view_selection()
 
-        # Assert
         assert view == "camper"
 
     def test_get_view_name_captains_book(self):
-        """Captain's Book selection should return camper view."""
         from seatrades_app.tabs.assignments_tab import get_view_selection
 
-        # Act
         view = get_view_selection("Captain's Book")
 
-        # Assert
         assert view == "camper"
 
     def test_get_view_name_cabin_leaders(self):
-        """Cabin Leaders selection should return cabin view."""
         from seatrades_app.tabs.assignments_tab import get_view_selection
 
-        # Act
         view = get_view_selection("Cabin Leaders")
 
-        # Assert
         assert view == "cabin"
 
     def test_get_view_name_seatrade_leaders(self):
-        """Seatrade Leaders selection should return seatrade view."""
         from seatrades_app.tabs.assignments_tab import get_view_selection
 
-        # Act
         view = get_view_selection("Seatrade Leaders")
 
-        # Assert
         assert view == "seatrade"
 
     def test_get_view_name_invalid_falls_back_to_camper(self):
-        """Invalid selection should fall back to camper view."""
         from seatrades_app.tabs.assignments_tab import get_view_selection
 
-        # Act
         view = get_view_selection("Invalid Option")
 
-        # Assert
         assert view == "camper"
 
     def test_render_view_captains_book(self, sample_assigned_df):
-        """render_view with Captain's Book should return camper-sorted dataframe."""
         from seatrades_app.tabs.assignments_tab import render_view
 
-        # Act
         result = render_view(sample_assigned_df, "Captain's Book")
 
-        # Assert
         assert result["camper"].tolist() == ["Alice", "Bob", "Carol", "Dave", "Zed"]
         assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
 
     def test_render_view_cabin_leaders(self, sample_assigned_df):
-        """render_view with Cabin Leaders should return cabin-sorted dataframe."""
         from seatrades_app.tabs.assignments_tab import render_view
 
-        # Act
         result = render_view(sample_assigned_df, "Cabin Leaders")
 
-        # Assert
         assert result["cabin"].tolist() == ["Cabin1", "Cabin1", "Cabin2", "Cabin2", "Cabin2"]
         assert result["camper"].tolist() == ["Bob", "Alice", "Carol", "Dave", "Zed"]
 
     def test_render_view_seatrade_leaders(self, sample_assigned_df):
-        """render_view with Seatrade Leaders should return seatrade-sorted dataframe."""
         from seatrades_app.tabs.assignments_tab import render_view
 
-        # Act
         result = render_view(sample_assigned_df, "Seatrade Leaders")
 
-        # Assert
         assert result["block"].tolist() == ["1a", "1a", "1a", "1a", "2a"]
         assert result["seatrade"].tolist() == ["Archery", "Archery", "Climbing", "Sailing", "Kayaking"]
 
     def test_captains_book_view_sorts_by_camper(self, sample_assigned_df):
         """Captain's Book view should sort by camper with correct column order."""
-        # Act
         result = prepare_assignment_view(sample_assigned_df, view="camper")
 
-        # Assert: Sorted by camper, correct columns (no 'assignment')
         assert result.columns.tolist() == [
             "camper",
             "cabin",
@@ -114,10 +86,8 @@ class TestAssignmentView:
 
     def test_sort_by_cabin(self, sample_assigned_df):
         """Cabin Leaders view should sort by cabin → block → camper."""
-        # Act
         result = prepare_assignment_view(sample_assigned_df, view="cabin")
 
-        # Assert: Sorted by cabin → block → camper
         assert result["cabin"].tolist() == ["Cabin1", "Cabin1", "Cabin2", "Cabin2", "Cabin2"]
         assert result["block"].tolist() == ["1a", "2a", "1a", "1a", "1a"]
         assert result["camper"].tolist() == ["Bob", "Alice", "Carol", "Dave", "Zed"]
@@ -125,16 +95,9 @@ class TestAssignmentView:
     def test_seatrade_leaders_view_sorts_by_block_seatrade_cabin_camper(
         self, seatrade_sort_df
     ):
-        """Seatrade Leaders view should sort by block → seatrade → cabin → camper."""
-        # Act
         result = prepare_assignment_view(seatrade_sort_df, view="seatrade")
 
-        # Assert: Sorted by block → seatrade → cabin → camper
-        # Block 1a before 2a
         assert result["block"].tolist() == ["1a", "1a", "1a", "2a"]
-        # Within 1a: Archery before Climbing (alphabetically)
         assert result["seatrade"].tolist() == ["Archery", "Archery", "Climbing", "Archery"]
-        # Within 1a+Archery: Cabin1 before Cabin2
         assert result["cabin"].tolist() == ["Cabin1", "Cabin2", "Cabin1", "Cabin2"]
-        # Within each group, campers sorted alphabetically
         assert result["camper"].tolist() == ["Alice", "Carol", "Bob", "Zed"]

--- a/tests/test_seatrades_app/test_assignments_tab.py
+++ b/tests/test_seatrades_app/test_assignments_tab.py
@@ -64,38 +64,6 @@ class TestAssignmentView:
         # Assert
         assert view == "camper"
 
-    def test_render_view_captains_book(self, sample_assigned_df):
-        """Should render Captain's Book view with correct columns."""
-        from seatrades_app.tabs.assignments_tab import render_view
-
-        # Act
-        result = render_view(sample_assigned_df, "Captain's Book")
-
-        # Assert
-        assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
-        assert result["camper"].tolist() == ["Alice", "Bob", "Carol", "Dave", "Zed"]
-
-    def test_render_view_cabin_leaders(self, sample_assigned_df):
-        """Should render Cabin Leaders view with correct columns."""
-        from seatrades_app.tabs.assignments_tab import render_view
-
-        # Act
-        result = render_view(sample_assigned_df, "Cabin Leaders")
-
-        # Assert
-        assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
-        assert result["cabin"].tolist() == ["Cabin1", "Cabin1", "Cabin2", "Cabin2", "Cabin2"]
-
-    def test_render_view_seatrade_leaders(self, seatrade_sort_df):
-        """Should render Seatrade Leaders view with correct columns."""
-        from seatrades_app.tabs.assignments_tab import render_view
-
-        # Act
-        result = render_view(seatrade_sort_df, "Seatrade Leaders")
-
-        # Assert
-        assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
-        assert result["block"].tolist() == ["1a", "1a", "1a", "2a"]
 
     def test_captains_book_view_sorts_by_camper(self, sample_assigned_df):
         """Captain's Book view should sort by camper with correct column order."""

--- a/tests/test_seatrades_app/test_assignments_tab.py
+++ b/tests/test_seatrades_app/test_assignments_tab.py
@@ -14,6 +14,89 @@ class TestAssignmentView:
         assert result["camper"].tolist() == ["Alice", "Carol"]
         assert "assignment" not in result.columns
 
+    def test_get_view_name_default(self):
+        """Default view selection should be Captain's Book."""
+        from seatrades_app.tabs.assignments_tab import get_view_selection
+
+        # Act
+        view = get_view_selection()
+
+        # Assert
+        assert view == "camper"
+
+    def test_get_view_name_captains_book(self):
+        """Captain's Book selection should return camper view."""
+        from seatrades_app.tabs.assignments_tab import get_view_selection
+
+        # Act
+        view = get_view_selection("Captain's Book")
+
+        # Assert
+        assert view == "camper"
+
+    def test_get_view_name_cabin_leaders(self):
+        """Cabin Leaders selection should return cabin view."""
+        from seatrades_app.tabs.assignments_tab import get_view_selection
+
+        # Act
+        view = get_view_selection("Cabin Leaders")
+
+        # Assert
+        assert view == "cabin"
+
+    def test_get_view_name_seatrade_leaders(self):
+        """Seatrade Leaders selection should return seatrade view."""
+        from seatrades_app.tabs.assignments_tab import get_view_selection
+
+        # Act
+        view = get_view_selection("Seatrade Leaders")
+
+        # Assert
+        assert view == "seatrade"
+
+    def test_get_view_name_invalid_falls_back_to_camper(self):
+        """Invalid selection should fall back to camper view."""
+        from seatrades_app.tabs.assignments_tab import get_view_selection
+
+        # Act
+        view = get_view_selection("Invalid Option")
+
+        # Assert
+        assert view == "camper"
+
+    def test_render_view_captains_book(self, sample_assigned_df):
+        """Should render Captain's Book view with correct columns."""
+        from seatrades_app.tabs.assignments_tab import render_view
+
+        # Act
+        result = render_view(sample_assigned_df, "Captain's Book")
+
+        # Assert
+        assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
+        assert result["camper"].tolist() == ["Alice", "Bob", "Carol", "Dave", "Zed"]
+
+    def test_render_view_cabin_leaders(self, sample_assigned_df):
+        """Should render Cabin Leaders view with correct columns."""
+        from seatrades_app.tabs.assignments_tab import render_view
+
+        # Act
+        result = render_view(sample_assigned_df, "Cabin Leaders")
+
+        # Assert
+        assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
+        assert result["cabin"].tolist() == ["Cabin1", "Cabin1", "Cabin2", "Cabin2", "Cabin2"]
+
+    def test_render_view_seatrade_leaders(self, seatrade_sort_df):
+        """Should render Seatrade Leaders view with correct columns."""
+        from seatrades_app.tabs.assignments_tab import render_view
+
+        # Act
+        result = render_view(seatrade_sort_df, "Seatrade Leaders")
+
+        # Assert
+        assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
+        assert result["block"].tolist() == ["1a", "1a", "1a", "2a"]
+
     def test_captains_book_view_sorts_by_camper(self, sample_assigned_df):
         """Captain's Book view should sort by camper with correct column order."""
         # Act

--- a/tests/test_seatrades_app/test_assignments_tab.py
+++ b/tests/test_seatrades_app/test_assignments_tab.py
@@ -64,6 +64,38 @@ class TestAssignmentView:
         # Assert
         assert view == "camper"
 
+    def test_render_view_captains_book(self, sample_assigned_df):
+        """render_view with Captain's Book should return camper-sorted dataframe."""
+        from seatrades_app.tabs.assignments_tab import render_view
+
+        # Act
+        result = render_view(sample_assigned_df, "Captain's Book")
+
+        # Assert
+        assert result["camper"].tolist() == ["Alice", "Bob", "Carol", "Dave", "Zed"]
+        assert result.columns.tolist() == ["camper", "cabin", "block", "seatrade", "preference"]
+
+    def test_render_view_cabin_leaders(self, sample_assigned_df):
+        """render_view with Cabin Leaders should return cabin-sorted dataframe."""
+        from seatrades_app.tabs.assignments_tab import render_view
+
+        # Act
+        result = render_view(sample_assigned_df, "Cabin Leaders")
+
+        # Assert
+        assert result["cabin"].tolist() == ["Cabin1", "Cabin1", "Cabin2", "Cabin2", "Cabin2"]
+        assert result["camper"].tolist() == ["Bob", "Alice", "Carol", "Dave", "Zed"]
+
+    def test_render_view_seatrade_leaders(self, sample_assigned_df):
+        """render_view with Seatrade Leaders should return seatrade-sorted dataframe."""
+        from seatrades_app.tabs.assignments_tab import render_view
+
+        # Act
+        result = render_view(sample_assigned_df, "Seatrade Leaders")
+
+        # Assert
+        assert result["block"].tolist() == ["1a", "1a", "1a", "1a", "2a"]
+        assert result["seatrade"].tolist() == ["Archery", "Archery", "Climbing", "Sailing", "Kayaking"]
 
     def test_captains_book_view_sorts_by_camper(self, sample_assigned_df):
         """Captain's Book view should sort by camper with correct column order."""


### PR DESCRIPTION
## Summary

Implements issue #15 from PRD #13 (CSV Export for Assignments).

- Replaces three static dataframe views with a single selectbox
- Three options: "Captain's Book", "Cabin Leaders", "Seatrade Leaders"
- Default selection: "Captain's Book"
- Only one view visible at a time

## Testing

- 12 tests pass (8 existing + 4 new for view selection logic)
- Tests verify correct sort order for each view
- Tests verify fallback behavior for invalid selections

## Blocked by

- #14 (Add 3 dataframe views) — already merged into feature/13-csv

🤖 Generated with [Claude Code](https://claude.com/claude-code)