### PR TITLE
Sort Captain's Book by camper upload order

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,11 +54,11 @@ A mapping of a camper to a seatrade in a specific block. Each camper gets exactl
 
 ### AssignmentSolution
 
-The resolved output of solving a seatrade scheduling problem. Produced by wrangling the solver's raw binary decision variables into a long-form DataFrame with columns: camper, seatrade, block, preference, cabin, assignment. Owned by the core package, not the problem builder or the UI.
+Self-contained and portable — no reference to the MILP model. Fields: assignments DataFrame, SolverStatus, plus domain data (campers, seatrades, preferences) needed by wrangling and visualization. Wrangling functions operate on this, not on the SchedulingProblem.
 
 ### SolverStatus
 
-Tracks the state of an in-progress or completed solve. Fields: percent, message, state (running/complete/error). Owned by the service layer, read by the UI via `@st.fragment` polling. Currently reports infeasibility as a message only; future work to add structured constraint-conflict diagnostics.
+A field inside `AssignmentSolution` (not a separate return). Tracks the outcome of a solve. Fields: state (SolverState enum: optimal/infeasible/error), gap (optimality gap as a float), message (human-readable, e.g. infeasibility detail). Progress monitoring (percent-complete during a running solve) stays in the UI layer via `@st.fragment` log polling — not in SolverStatus.
 
 ### Assignment Export
 
@@ -95,7 +95,7 @@ flowchart LR
     Val --> Prob
     Prob -->|pulp.LpProblem| Solve
     Solve -->|AssignmentSolution| Result
-    Solve -->|SolverStatus| Fragment
+    Solve -->|AssignmentSolution| Fragment
     Result --> Display
 ```
 
@@ -104,11 +104,10 @@ flowchart LR
 ```
 1. User uploads CSVs or uses simulation → app/ calls seatrades.simulation
 2. Input DataFrames validated → seatrades.preferences (Pandera + cross-ref)
-3. SchedulingProblem(prefs, config) → holds parsed state
-4. problem.build() → pulp.LpProblem
-5. solver.run(problem, config) → AssignmentSolution + SolverStatus
-6. UI reads SolverStatus via @st.fragment, displays AssignmentSolution
-7. AssignmentSolution.export(view="camper"|"cabin"|"seatrade") → formatted DataFrame
+3. SchedulingProblem(campers, cabins, seatrades, blocks, fleets, preferences) → holds parsed domain state
+4. solver.run(problem, config) → calls problem.build(config) internally, returns AssignmentSolution (with SolverStatus inside)
+5. UI reads AssignmentSolution.status via @st.fragment, displays assignments
+6. AssignmentSolution.export(view="camper"|"cabin"|"seatrade") → formatted DataFrame
 ```
 
 ## Optimization Problem
@@ -143,9 +142,9 @@ The scheduler solves a mixed-integer linear programming problem with these const
 
 | Module | Owns |
 |--------|------|
-| `scheduling_problem.py` | `SchedulingProblem` — holds parsed domain state, builds MILP (variables, constraints, objective). Does NOT solve. |
-| `solver.py` | Orchestrate solve, track progress (`SolverStatus`), background thread |
-| `results.py` | `AssignmentSolution` — wrangle + export views |
+| `problem.py` | `SchedulingProblem` — holds parsed domain state, builds MILP (variables, constraints, objective) when `.build(config)` is called. Does NOT solve. Config (weights, limits, solver settings) is passed at build time, not init — allows rebuilding with different configs against the same domain data. |
+| `solver.py` | `solver.run(problem, config) -> AssignmentSolution` — orchestrates build + solve + wrangle. Calls `problem.build(config)` internally. Manages solver thread and CBC log reading. |
+| `results.py` | `AssignmentSolution` dataclass + free functions for wrangling (`wrangle_assignments_to_longform`, `wrangle_assignments_to_wideform`, `prepare_seatrade_leaders`) and export views. Functions take `AssignmentSolution`, not the problem. |
 | `visualization.py` | Build `alt.Chart` specs from `AssignmentSolution`. No Streamlit dependency — renders in any Altair-capable frontend. |
 | `preferences.py` | Pandera schemas + cross-reference validation (e.g., camper prefs must name seatrades that exist) |
 | `simulation.py` | Generate mock camper + seatrade data |
@@ -155,13 +154,13 @@ The scheduler solves a mixed-integer linear programming problem with these const
 
 Resolved during grilling session 2026-05-05. Open questions marked with [OPEN].
 
-1. **`Seatrades` class → split into SchedulingProblem + solver + results.** Problem builder owns variables/constraints/objective. Solving is separate. Wrangling is separate. `SchedulingProblem` is stateful (holds parsed domain state) because the wrangler needs the same state — avoids re-parsing or building a second context object.
+1. **`Seatrades` class → split into SchedulingProblem + solver + results.** Problem builder owns variables/constraints/objective. Solving is separate. Wrangling is separate. `SchedulingProblem` is stateful (holds parsed domain state) because the wrangler needs the same state — avoids re-parsing or building a second context object. Module is `problem.py` (not `scheduling_problem.py`). Config passed at `.build(config)` time, not init — allows rebuilding with different configs against same domain data.
 
-2. **Solver produces `AssignmentSolution`, not raw pulp object.** Clean boundary: problem goes in, solution comes out. No leaking PuLP internals.
+2. **Solver produces `AssignmentSolution`, not raw pulp object.** Clean boundary: problem goes in, solution comes out. No leaking PuLP internals. `AssignmentSolution` is self-contained and portable — holds assignments DataFrame, SolverStatus, and domain data needed by wrangling/visualization. `SolverStatus` is a field inside `AssignmentSolution` (not a separate return): state is a `SolverState` enum (optimal/infeasible/error), `gap` is the optimality gap, `message` for human-readable detail. Progress monitoring stays in UI layer only.
 
-3. **Service function `solver.run(problem, config) -> AssignmentSolution + SolverStatus`.** UI calls one function. No solver orchestration in the presentation layer.
+3. **Service function `solver.run(problem, config) -> AssignmentSolution`.** UI calls one function. `solver.run` calls `problem.build(config)` internally. No solver orchestration in the presentation layer.
 
-4. **Solver monitoring splits: service layer runs solver + reads CBC log, UI polls `SolverStatus` via `@st.fragment`.** PuLP/CBC doesn't support mid-solve callbacks — log file is the only progress signal. `@st.fragment(run_every=...)` replaces manual `while`+`sleep` polling.
+4. **Solver monitoring splits: service layer runs solver + reads CBC log, UI polls `AssignmentSolution.status` via `@st.fragment`.** PuLP/CBC doesn't support mid-solve callbacks — log file is the only progress signal. `@st.fragment(run_every=...)` replaces manual `while`+`sleep` polling. Progress percent stays in UI polling layer, not in SolverStatus.
 
 5. **Simulation data generation moves to service layer** (`seatrades/simulation.py`). It's domain logic, not UI.
 

--- a/docs/adr/0003-service-layer-architecture.md
+++ b/docs/adr/0003-service-layer-architecture.md
@@ -6,15 +6,17 @@ The application splits into two packages: `seatrades/` (service layer — domain
 
 ## Considered Options
 
-1. **Service layer** — A thin service function (`solver.run(problem, config) -> AssignmentSolution + SolverStatus`) sits between the UI and the optimizer. The UI calls one function; all orchestration happens in the service layer.
+1. **Service layer** — A thin service function (`solver.run(problem, config) -> AssignmentSolution`) sits between the UI and the optimizer. The UI calls one function; all orchestration happens in the service layer. `solver.run` calls `problem.build(config)` internally. `SolverStatus` is a field inside `AssignmentSolution`, not a separate return — the solution is self-contained and portable.
 
 2. **Ad-hoc** — The UI constructs `SchedulingProblem`, calls `.solve()` on the problem object, passes raw output to a wrangler, gets back results. No service layer.
 
 We chose option 1 because the solver orchestration (build → solve → wrangle) is a workflow, not a UI concern. A service function gives one place to test the full pipeline without Streamlit and one clean seam for the UI to call. Option 2 keeps solver logic tangled in `assignments_tab.py`, which already has 300 lines mixing thread management, log parsing, and progress display.
 
+Config is passed at `build(config)` time, not at `SchedulingProblem.__init__` time. This allows rebuilding the MILP with different weights, limits, or solver settings against the same domain data without re-constructing the problem. The trade-off is that the problem object is not ready to solve until `build()` is called, but `solver.run()` handles this internally so callers don't need to think about it.
+
 ## Consequences
 
 - Simulation data generation, validation, and config dataclasses move out of tab files into `seatrades/simulation.py`, `seatrades/preferences.py`, and `seatrades/config.py`.
 - Cross-tab coupling (`_clear_optimization_results` imported across tabs) disappears — state management moves to session state keys via `app/state.py`.
-- The `Seatrades` class (426 lines, monolith) splits into `SchedulingProblem` (stateful problem builder), `solver.py` (orchestration), and `results.py` (wrangling + export views).
+- The `Seatrades` class (426 lines, monolith) splits into `SchedulingProblem` (stateful problem builder in `problem.py`), `solver.py` (orchestration), and `results.py` (`AssignmentSolution` dataclass + free wrangling/export functions). Wrangling functions take `AssignmentSolution`, not the problem object — keeps results portable.
 - `seatrades_app/` renames to `app/` following Streamlit convention.

--- a/docs/prd/assignments-export.md
+++ b/docs/prd/assignments-export.md
@@ -10,7 +10,7 @@ Keep the existing Altair visualization as the primary view. Add two table views 
 
 ### Why two views instead of three
 
-The original design had three views (Captain's Book, Cabin Leaders, Seatrade Leaders). After QA review, the Cabin Leaders view was removed because it was identical to the Captain's Book in columns — only the sort order differed, and the Captain's Book already sorts by cabin → camper, which satisfies the cabin distribution use case.
+The original design had three views (Captain's Book, Cabin Leaders, Seatrade Leaders). After QA review, the Cabin Leaders view was removed because it was identical to the Captain's Book in columns — only the sort order differed. The Captain's Book now supports both sort orders: the default cabin → camper sort, and the uploaded camper order (which is what the Cabin Leaders view would have provided).
 
 ### Why wide form for the Captain's Book
 
@@ -38,7 +38,7 @@ The sub-block notation encodes fleet assignment: "a" means the cabin does their 
 
 | View | Shape | Sort Order | Columns |
 |------|-------|------------|---------|
-| Captain's Book | Wide (1 row/camper) | cabin → camper | cabin, camper, Seatrade 1a, Seatrade 1b, Seatrade 2a, Seatrade 2b |
+| Captain's Book | Wide (1 row/camper) | uploaded camper order (default: cabin → camper) | cabin, camper, Seatrade 1a, Seatrade 1b, Seatrade 2a, Seatrade 2b |
 | Seatrade Leaders | Long (1 row/assignment) | block → seatrade → cabin → camper | block, seatrade, camper, cabin |
 
 Sub-block columns (1a, 1b, 2a, 2b) encode fleet assignment. Each camper fills exactly 2 of 4 seatrade columns; the rest are blank. Preference ranks are omitted from both views.
@@ -53,7 +53,9 @@ Sub-block columns (1a, 1b, 2a, 2b) encode fleet assignment. Each camper fills ex
 
 - Test that Captain's Book produces wide-form with correct columns (cabin, camper, Seatrade 1a, Seatrade 1b, Seatrade 2a, Seatrade 2b)
 - Test that each camper row has exactly 2 of 4 seatrade columns filled
-- Test that Captain's Book sorts by cabin → camper
+- Test that Captain's Book sorts by cabin → camper when no `camper_order` is provided
+- Test that Captain's Book sorts by uploaded camper order when `camper_order` is passed
+- Test that passing `camper_order` with a missing camper raises `ValueError`
 - Test that Seatrade Leaders sorts by block → seatrade → cabin → camper
 - Test that Seatrade Leaders has no preference or assignment columns
 - Test that CSV download produces valid CSV with correct column order

--- a/seatrades/seatrades.py
+++ b/seatrades/seatrades.py
@@ -460,12 +460,12 @@ def wrangle_assignments_to_wideform(
         fill_value="",
     )
 
-    # Enforce column order
-    col_order = ["Seatrade 1a", "Seatrade 1b", "Seatrade 2a", "Seatrade 2b"]
-    for col in col_order:
-        if col not in pivot.columns:
-            pivot[col] = ""
-    pivot = pivot[col_order]
+    # pivot_table may omit empty block columns; ensure fixed order
+    seatrade_block_columns = ["Seatrade 1a", "Seatrade 1b", "Seatrade 2a", "Seatrade 2b"]
+    for column in seatrade_block_columns:
+        if column not in pivot.columns:
+            pivot[column] = ""
+    pivot = pivot[seatrade_block_columns]
 
     if camper_order is not None:
         wideform_campers = pivot.index.get_level_values("camper").tolist()
@@ -478,14 +478,13 @@ def wrangle_assignments_to_wideform(
     pivot = pivot.reset_index()
 
     if camper_order is not None:
-        camper_sort_key = {name: i for i, name in enumerate(camper_order)}
-        pivot["_sort"] = pivot["camper"].map(camper_sort_key)
-        pivot = pivot.sort_values(by="_sort", kind="stable").drop(columns="_sort")
+        camper_rank = {name: i for i, name in enumerate(camper_order)}
+        pivot["_rank"] = pivot["camper"].map(camper_rank)
+        pivot = pivot.sort_values(by="_rank", kind="stable").drop(columns="_rank")
     else:
         pivot = pivot.sort_values(by=["cabin", "camper"], kind="stable")
 
-    # Reorder final columns
-    pivot = pivot[["cabin", "camper"] + col_order]
+    pivot = pivot[["cabin", "camper"] + seatrade_block_columns]
 
     return pivot
 

--- a/seatrades/seatrades.py
+++ b/seatrades/seatrades.py
@@ -434,12 +434,19 @@ class Seatrades:
         return df
 
 
-def wrangle_assignments_to_wideform(longform_df: pd.DataFrame) -> pd.DataFrame:
+def wrangle_assignments_to_wideform(
+    longform_df: pd.DataFrame,
+    camper_order: Optional[List[str]] = None,
+) -> pd.DataFrame:
     """Pivot long-form assignments to wide-form Captain's Book.
 
     1 row per camper. Columns: cabin, camper, Seatrade 1a, Seatrade 1b,
     Seatrade 2a, Seatrade 2b. Each camper fills exactly 2 of the 4 seatrade
     columns (one per block); the rest are blank.
+
+    When camper_order is provided, rows are sorted to match that order.
+    When None, rows are sorted by cabin → camper.
+    Raises ValueError if a camper in the wideform is missing from camper_order.
     """
     assigned = longform_df[longform_df["assignment"] == 1.0].copy()
     assigned["block_label"] = "Seatrade " + assigned["block"]
@@ -460,9 +467,23 @@ def wrangle_assignments_to_wideform(longform_df: pd.DataFrame) -> pd.DataFrame:
             pivot[col] = ""
     pivot = pivot[col_order]
 
-    # Sort by cabin → camper, flatten multi-index
-    pivot = pivot.sort_values(by=["cabin", "camper"], kind="stable")
+    if camper_order is not None:
+        wideform_campers = pivot.index.get_level_values("camper").tolist()
+        missing = set(wideform_campers) - set(camper_order)
+        if missing:
+            raise ValueError(
+                f"camper_order is missing campers present in wideform: {sorted(missing)}"
+            )
+        pivot = pivot.reindex(camper_order, level="camper")
+    else:
+        pivot = pivot.sort_values(by=["cabin", "camper"], kind="stable")
+
     pivot = pivot.reset_index()
+
+    if camper_order is not None:
+        camper_sort_key = {name: i for i, name in enumerate(camper_order)}
+        pivot["_sort"] = pivot["camper"].map(camper_sort_key)
+        pivot = pivot.sort_values(by="_sort", kind="stable").drop(columns="_sort")
 
     # Reorder final columns
     pivot = pivot[["cabin", "camper"] + col_order]

--- a/seatrades/seatrades.py
+++ b/seatrades/seatrades.py
@@ -474,9 +474,6 @@ def wrangle_assignments_to_wideform(
             raise ValueError(
                 f"camper_order is missing campers present in wideform: {sorted(missing)}"
             )
-        pivot = pivot.reindex(camper_order, level="camper")
-    else:
-        pivot = pivot.sort_values(by=["cabin", "camper"], kind="stable")
 
     pivot = pivot.reset_index()
 
@@ -484,6 +481,8 @@ def wrangle_assignments_to_wideform(
         camper_sort_key = {name: i for i, name in enumerate(camper_order)}
         pivot["_sort"] = pivot["camper"].map(camper_sort_key)
         pivot = pivot.sort_values(by="_sort", kind="stable").drop(columns="_sort")
+    else:
+        pivot = pivot.sort_values(by=["cabin", "camper"], kind="stable")
 
     # Reorder final columns
     pivot = pivot[["cabin", "camper"] + col_order]

--- a/seatrades_app/tabs/assignments_tab.py
+++ b/seatrades_app/tabs/assignments_tab.py
@@ -4,7 +4,7 @@ import queue
 import re
 import threading
 import time
-from typing import Literal
+from typing import List, Literal, Optional
 
 import streamlit as st
 import pandas as pd
@@ -66,7 +66,9 @@ class AssignmentsTab:
                     key="assignment_view_selector",
                 )
 
-                st.dataframe(render_view(longform_df, selected_view))
+                st.dataframe(
+                    render_view(longform_df, selected_view, camper_order=seatrades_obj.campers)
+                )
 
 
 @st.dialog("Welcome to the Keats Seatrade Scheduler", width="large")
@@ -258,7 +260,11 @@ def _run_assignment_and_capture_logs(
         status_queue.put(-1)
 
 
-def render_view(df: pd.DataFrame, selection: Literal["Captain's Book", "Seatrade Leaders"]) -> pd.DataFrame:
+def render_view(
+    df: pd.DataFrame,
+    selection: Literal["Captain's Book", "Seatrade Leaders"],
+    camper_order: Optional[List[str]] = None,
+) -> pd.DataFrame:
     """Render the selected assignment view.
 
     Parameters
@@ -267,6 +273,9 @@ def render_view(df: pd.DataFrame, selection: Literal["Captain's Book", "Seatrade
         Longform assignments dataframe.
     selection : str
         Selectbox label: "Captain's Book" or "Seatrade Leaders".
+    camper_order : Optional[List[str]]
+        Ordered camper names for Captain's Book sort. Passed through to
+        wrangle_assignments_to_wideform. Ignored for Seatrade Leaders.
 
     Returns
     -------
@@ -274,5 +283,5 @@ def render_view(df: pd.DataFrame, selection: Literal["Captain's Book", "Seatrade
         Filtered, sorted, and re-ordered dataframe for display.
     """
     if selection == "Captain's Book":
-        return wrangle_assignments_to_wideform(df)
+        return wrangle_assignments_to_wideform(df, camper_order=camper_order)
     return prepare_seatrade_leaders(df)

--- a/seatrades_app/tabs/assignments_tab.py
+++ b/seatrades_app/tabs/assignments_tab.py
@@ -261,18 +261,18 @@ def _run_assignment_and_capture_logs(
 
 
 def render_view(
-    df: pd.DataFrame,
-    selection: Literal["Captain's Book", "Seatrade Leaders"],
+    longform_df: pd.DataFrame,
+    view_name: Literal["Captain's Book", "Seatrade Leaders"],
     camper_order: Optional[List[str]] = None,
 ) -> pd.DataFrame:
     """Render the selected assignment view.
 
     Parameters
     ----------
-    df : pd.DataFrame
+    longform_df : pd.DataFrame
         Longform assignments dataframe.
-    selection : str
-        Selectbox label: "Captain's Book" or "Seatrade Leaders".
+    view_name : Literal["Captain's Book", "Seatrade Leaders"]
+        Which assignment view to render.
     camper_order : Optional[List[str]]
         Ordered camper names for Captain's Book sort. Passed through to
         wrangle_assignments_to_wideform. Ignored for Seatrade Leaders.
@@ -282,6 +282,6 @@ def render_view(
     pd.DataFrame
         Filtered, sorted, and re-ordered dataframe for display.
     """
-    if selection == "Captain's Book":
-        return wrangle_assignments_to_wideform(df, camper_order=camper_order)
-    return prepare_seatrade_leaders(df)
+    if view_name == "Captain's Book":
+        return wrangle_assignments_to_wideform(longform_df, camper_order=camper_order)
+    return prepare_seatrade_leaders(longform_df)

--- a/tests/test_seatrades/test_wideform.py
+++ b/tests/test_seatrades/test_wideform.py
@@ -90,6 +90,27 @@ class TestWideformSort:
         assert result["cabin"].tolist() == ["Cabin1", "Cabin1", "Cabin2", "Cabin2"]
 
 
+class TestCamperOrderSort:
+    """When camper_order is provided, rows follow that order."""
+
+    def test_sorts_by_camper_order(self, longform_assigned):
+        """Rows follow camper_order, not cabin → camper."""
+        camper_order = ["Dave", "Carol", "Bob", "Alice"]
+        result = wrangle_assignments_to_wideform(longform_assigned, camper_order=camper_order)
+        assert result["camper"].tolist() == ["Dave", "Carol", "Bob", "Alice"]
+
+    def test_camper_order_missing_camper_raises(self, longform_assigned):
+        """ValueError if camper in wideform is missing from camper_order."""
+        incomplete_order = ["Alice", "Bob"]
+        with pytest.raises(ValueError, match="camper_order"):
+            wrangle_assignments_to_wideform(longform_assigned, camper_order=incomplete_order)
+
+    def test_camper_order_none_preserves_cabin_sort(self, longform_assigned):
+        """camper_order=None preserves current cabin → camper sort."""
+        result = wrangle_assignments_to_wideform(longform_assigned, camper_order=None)
+        assert result["camper"].tolist() == ["Alice", "Bob", "Carol", "Dave"]
+
+
 class TestSeatradeLeaders:
     def test_columns_are_block_seatrade_camper_cabin(self, seatrade_sort_df):
         """Seatrade Leaders should have columns: block, seatrade, camper, cabin."""

--- a/tests/test_seatrades_app/test_assignments_tab.py
+++ b/tests/test_seatrades_app/test_assignments_tab.py
@@ -6,7 +6,7 @@ transitional and will become dead weight once the old function names are fully g
 import pytest
 
 from seatrades_app.tabs.assignments_tab import render_view
-from seatrades.seatrades import wrangle_assignments_to_wideform, prepare_seatrade_leaders
+from seatrades.seatrades import wrangle_assignments_to_wideform
 
 
 class TestRemovedViews:

--- a/tests/test_seatrades_app/test_assignments_tab.py
+++ b/tests/test_seatrades_app/test_assignments_tab.py
@@ -31,7 +31,26 @@ class TestRenderView:
             "Seatrade 2a", "Seatrade 2b",
         ]
 
+    def test_captains_book_sorts_by_camper_order(self, seatrade_sort_df):
+        """Captain's Book with camper_order should sort rows by that order."""
+        camper_order = ["Carol", "Zed", "Bob", "Alice"]
+        result = render_view(seatrade_sort_df, "Captain's Book", camper_order=camper_order)
+        assert result["camper"].tolist() == ["Carol", "Zed", "Bob", "Alice"]
+
+    def test_captains_book_without_camper_order_uses_cabin_sort(self, seatrade_sort_df):
+        """Captain's Book without camper_order should sort by cabin → camper."""
+        result = render_view(seatrade_sort_df, "Captain's Book")
+        assert result["camper"].tolist() == ["Alice", "Bob", "Carol", "Zed"]
+
     def test_seatrade_leaders_returns_simplified_longform(self, seatrade_sort_df):
         """Selecting Seatrade Leaders should return block, seatrade, camper, cabin."""
         result = render_view(seatrade_sort_df, "Seatrade Leaders")
         assert result.columns.tolist() == ["block", "seatrade", "camper", "cabin"]
+
+    def test_seatrade_leaders_ignores_camper_order(self, seatrade_sort_df):
+        """Seatrade Leaders view should ignore camper_order."""
+        result_without = render_view(seatrade_sort_df, "Seatrade Leaders")
+        result_with = render_view(
+            seatrade_sort_df, "Seatrade Leaders", camper_order=["Zed", "Alice"]
+        )
+        assert result_without.equals(result_with)


### PR DESCRIPTION
## Summary

- Adds optional `camper_order` parameter to `wrangle_assignments_to_wideform` — when provided, rows sort by uploaded camper order; when None, preserves existing cabin → camper sort
- Raises `ValueError` if `camper_order` is missing any camper present in the wideform
- `render_view` now forwards `seatrades_obj.campers` for Captain's Book (minimal coupling — list only, not the whole object)
- Seatrade Leaders view is unchanged

Closes #32

## Test plan

- [x] `camper_order=None` preserves cabin → camper sort (existing test + new explicit test)
- [x] `camper_order` provided sorts rows by that order
- [x] Missing camper in `camper_order` raises `ValueError`
- [x] `render_view` passes `camper_order` for Captain's Book
- [x] `render_view` ignores `camper_order` for Seatrade Leaders
- [x] All 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)