### PR TITLE
Conditional campers_min per session (#48)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -151,7 +151,7 @@ The scheduler solves a mixed-integer linear programming problem with these const
 
 1. **One seatrade per block** - Each camper assigned to exactly 1 seatrade in each block
 2. **No duplicates** - Camper cannot take same seatrade in both blocks
-3. **Capacity limits** - Seatrade capacity enforced (min/max per session)
+3. **Capacity limits** - Conditional per session: a session either runs (camper count within `[campers_min, campers_max]`) or doesn't run (0 campers). The minimum is a viability threshold — enforced only when the session runs — not a forced quota. See Decisions-Log #14.
 4. **Preference only** - Campers only assigned seatrades they ranked
 5. **Top-2 guarantee** - Campers guaranteed one of their top 2 choices
 6. **Cabin max per seatrade** - Max k campers from same cabin in one seatrade (by default k=4)
@@ -230,6 +230,8 @@ Resolved during grilling session 2026-05-05. Open questions marked with [OPEN].
 12. **SchedulingProblem receives 2 DataFrames, not 6 params.** After `preferences.py` joins the 3 source DataFrames, the problem builder gets `joined_campers` (identity + preferences merged) and `seatrade_setup` (name, min, max).
 
 13. **Camper relationships are hard MILP constraints with a dedicated input DataFrame.** Schema: `(cabin_1, camper_1, cabin_2, camper_2, relationship)` with values `friends`, `besties`, `frenemies`. Uses composite keys matching existing domain model. Session = seatrade + fleet + block; all relationship constraints operate on sessions. Validation rejects self-pairs and duplicate pairs (regardless of order). Relationships are optional — no constraints by default. Diagnosing contradictory constraint chains causing infeasibility is future work. PRD: `docs/prd/camper-relationships.md`.
+
+14. **`campers_min` is a conditional minimum per session (issue #48).** A session may have either 0 campers (it doesn't run) or a count within `[campers_min, campers_max]` (it runs) — nothing in between. This reframes `campers_min` as a *viability threshold* ("worth running only with N campers") rather than a forced quota, and removes a class of spurious infeasibility where an unranked seatrade's floor was force-filled. Constraints-only — no objective term or penalty; whether a session empties is still driven by the existing objective (notably `sparsity_weight`). Reuses the existing per-session `seatrade_assignment` indicator (the "session runs" binary) — no new variable. Both bounds are gated on that indicator in `_add_capacity_constraints`. Default-on via `OptimizationConfig.allow_empty_sessions` (not exposed in the UI); setting it `False` restores the legacy hard floor. Only *widens* the feasible region — never makes a feasible problem infeasible; with `campers_min = 0` it is a no-op.
 
 ## Tech Stack
 

--- a/seatrades/config.py
+++ b/seatrades/config.py
@@ -20,6 +20,10 @@ class OptimizationConfig:
     cabins_weight: int = 2
     sparsity_weight: int = 1
     max_seatrades_per_fleet: Optional[int] = None
+    # When True (default), campers_min is a conditional minimum: a session runs with a
+    # count in [min, max] or doesn't run (0 campers). When False, restores the legacy
+    # hard floor that force-fills campers_min into every session. Not exposed in the UI.
+    allow_empty_sessions: bool = True
     log_path: Path = SEATRADES_LOG_PATH
     # Accepts None as input, but __post_init__ guarantees a solver afterward —
     # typed non-Optional so callers (and mypy) can treat it as always present.

--- a/seatrades/problem.py
+++ b/seatrades/problem.py
@@ -173,14 +173,14 @@ class SchedulingProblem:
             seatrade = seatrade_name(s)
             campers_min = self.seatrades_prefs.loc[seatrade, "campers_min"]
             campers_max = self.seatrades_prefs.loc[seatrade, "campers_max"]
-            count = pulp.lpSum([camper_assignments[c][s] for c in self.campers])
+            camper_count = pulp.lpSum([camper_assignments[c][s] for c in self.campers])
             if config.allow_empty_sessions:
                 running = seatrade_assignment[block][seatrade]
-                problem += (count >= campers_min * running, f"Min_if_running_{s}")
-                problem += (count <= campers_max * running, f"Max_if_running_{s}")
+                problem += (camper_count >= campers_min * running, f"Min_if_running_{s}")
+                problem += (camper_count <= campers_max * running, f"Max_if_running_{s}")
             else:
-                problem += (count >= campers_min, f"More_than_{campers_min}_in_{s}")
-                problem += (count <= campers_max, f"Less_than_{campers_max}_in_{s}")
+                problem += (camper_count >= campers_min, f"More_than_{campers_min}_in_{s}")
+                problem += (camper_count <= campers_max, f"Less_than_{campers_max}_in_{s}")
 
     def _add_preference_constraints(self, problem: pulp.LpProblem, camper_assignments: VarDict) -> None:
         """Campers cannot be assigned to seatrades they didn't request."""

--- a/seatrades/problem.py
+++ b/seatrades/problem.py
@@ -11,6 +11,11 @@ BLOCKS = ["1a", "1b", "2a", "2b"]
 FLEET_BLOCKS = [["1a", "1b"], ["2a", "2b"]]
 
 
+def block_name(seatrade_full: str) -> str:
+    """Strip the seatrade suffix from a full seatrade name (``1a_Archery`` → ``1a``)."""
+    return seatrade_full.split("_", 1)[0]
+
+
 def seatrade_name(seatrade_full: str) -> str:
     """Strip the block prefix from a full seatrade name (``1a_Archery`` → ``Archery``)."""
     return seatrade_full.split("_", 1)[1]
@@ -164,7 +169,7 @@ class SchedulingProblem:
         legacy hard floor force-fills ``campers_min`` into every session.
         """
         for s in self.seatrades_full:
-            block = s.split("_", 1)[0]
+            block = block_name(s)
             seatrade = seatrade_name(s)
             campers_min = self.seatrades_prefs.loc[seatrade, "campers_min"]
             campers_max = self.seatrades_prefs.loc[seatrade, "campers_max"]

--- a/seatrades/problem.py
+++ b/seatrades/problem.py
@@ -91,7 +91,7 @@ class SchedulingProblem:
         )
         self._add_assignment_constraints(problem, camper_assignments)
         self._add_no_duplicate_seatrade_constraints(problem, camper_assignments)
-        self._add_capacity_constraints(problem, camper_assignments)
+        self._add_capacity_constraints(problem, camper_assignments, seatrade_assignment, config)
         self._add_preference_constraints(problem, camper_assignments)
         self._add_top2_guarantee_constraints(problem, camper_assignments)
         self._add_cabin_max_constraints(problem, camper_assignments)
@@ -149,20 +149,33 @@ class SchedulingProblem:
                     f"{c}_cant_take_{seatrade}_in_both_blocks",
                 )
 
-    def _add_capacity_constraints(self, problem: pulp.LpProblem, camper_assignments: VarDict) -> None:
-        """Seatrade camper counts stay within min/max capacity bounds."""
+    def _add_capacity_constraints(
+        self,
+        problem: pulp.LpProblem,
+        camper_assignments: VarDict,
+        seatrade_assignment: VarDict,
+        config: OptimizationConfig,
+    ) -> None:
+        """Bound each session's camper count by min/max capacity.
+
+        With ``allow_empty_sessions`` (default), the min/max bounds are gated on the
+        per-session ``running`` indicator: a session may have 0 campers (it doesn't run)
+        or a count in ``[campers_min, campers_max]`` (it runs). With the flag off, the
+        legacy hard floor force-fills ``campers_min`` into every session.
+        """
         for s in self.seatrades_full:
+            block = s.split("_", 1)[0]
             seatrade = seatrade_name(s)
-            seatrade_campers_min = self.seatrades_prefs.loc[seatrade, "campers_min"]
-            problem += (
-                pulp.lpSum([camper_assignments[c][s] for c in self.campers]) >= seatrade_campers_min,
-                f"More_than_{seatrade_campers_min}_in_{s}",
-            )
-            seatrade_campers_max = self.seatrades_prefs.loc[seatrade, "campers_max"]
-            problem += (
-                pulp.lpSum([camper_assignments[c][s] for c in self.campers]) <= seatrade_campers_max,
-                f"Less_than_{seatrade_campers_max}_in_{s}",
-            )
+            campers_min = self.seatrades_prefs.loc[seatrade, "campers_min"]
+            campers_max = self.seatrades_prefs.loc[seatrade, "campers_max"]
+            count = pulp.lpSum([camper_assignments[c][s] for c in self.campers])
+            if config.allow_empty_sessions:
+                running = seatrade_assignment[block][seatrade]
+                problem += (count >= campers_min * running, f"Min_if_running_{s}")
+                problem += (count <= campers_max * running, f"Max_if_running_{s}")
+            else:
+                problem += (count >= campers_min, f"More_than_{campers_min}_in_{s}")
+                problem += (count <= campers_max, f"Less_than_{campers_max}_in_{s}")
 
     def _add_preference_constraints(self, problem: pulp.LpProblem, camper_assignments: VarDict) -> None:
         """Campers cannot be assigned to seatrades they didn't request."""

--- a/tests/test_seatrades/test_problem.py
+++ b/tests/test_seatrades/test_problem.py
@@ -4,7 +4,23 @@ import pandas as pd
 import pulp
 
 from seatrades.config import OptimizationConfig
-from seatrades.problem import SchedulingProblem
+from seatrades.problem import SchedulingProblem, block_name, seatrade_name
+
+
+class TestNamingHelpers:
+    """``block_name`` and ``seatrade_name`` are complementary halves of the
+    ``block_seatrade`` full-name format."""
+
+    def test_block_name_strips_seatrade_suffix(self):
+        assert block_name("1a_Archery") == "1a"
+
+    def test_seatrade_name_strips_block_prefix(self):
+        assert seatrade_name("1a_Archery") == "Archery"
+
+    def test_helpers_split_on_first_underscore_only(self):
+        # Seatrade names may themselves contain underscores; only the first splits.
+        assert block_name("2b_Deep_Sea_Fishing") == "2b"
+        assert seatrade_name("2b_Deep_Sea_Fishing") == "Deep_Sea_Fishing"
 
 
 class TestSchedulingProblemInit:

--- a/tests/test_seatrades/test_problem.py
+++ b/tests/test_seatrades/test_problem.py
@@ -203,14 +203,28 @@ class TestSchedulingProblemConstraintGroups:
         assert len(problem.constraints) == len(sp.seatrades) * len(sp.campers)
         assert any("_cant_take_" in name and "_in_both_blocks" in name for name in problem.constraints)
 
-    def test_add_capacity_constraints(self, scheduling_problem):
+    def test_add_capacity_constraints(self, scheduling_problem, default_config):
         sp = scheduling_problem
         problem = pulp.LpProblem("test_capacity")
         vars_ = self._make_vars(sp)
 
-        sp._add_capacity_constraints(problem, vars_["camper_assignments"])
+        sp._add_capacity_constraints(problem, vars_["camper_assignments"], vars_["seatrade_assignment"], default_config)
 
-        # 2 constraints per seatrade_full entry (min + max)
+        # Conditional min (default): 2 constraints per seatrade_full entry, both gated on
+        # the per-session running indicator.
+        assert len(problem.constraints) == 2 * len(sp.seatrades_full)
+        assert any("Min_if_running" in name for name in problem.constraints)
+        assert any("Max_if_running" in name for name in problem.constraints)
+
+    def test_add_capacity_constraints_legacy_force_fill(self, scheduling_problem):
+        sp = scheduling_problem
+        problem = pulp.LpProblem("test_capacity_legacy")
+        vars_ = self._make_vars(sp)
+        legacy_config = OptimizationConfig(allow_empty_sessions=False)
+
+        sp._add_capacity_constraints(problem, vars_["camper_assignments"], vars_["seatrade_assignment"], legacy_config)
+
+        # Legacy hard floor: ungated min + max per seatrade_full entry.
         assert len(problem.constraints) == 2 * len(sp.seatrades_full)
         assert any("More_than" in name for name in problem.constraints)
         assert any("Less_than" in name for name in problem.constraints)

--- a/tests/test_seatrades/test_solver.py
+++ b/tests/test_seatrades/test_solver.py
@@ -309,6 +309,20 @@ class TestConditionalMinCapacity:
         assert notpicked_cols  # the columns exist...
         assert solution.assignments[notpicked_cols].to_numpy().sum() == 0  # ...but hold no campers
 
+    def test_dropped_session_absent_from_exports(self):
+        """A non-running session yields no assigned rows, so it never reaches the
+        wrangled exports/charts (user story 5)."""
+        problem = SchedulingProblem(self._joined, self._setup)
+        config = OptimizationConfig(solver=pulp.apis.PULP_CBC_CMD(msg=0))
+        solution = run(problem, config)
+
+        longform = wrangle_assignments_to_longform(solution)
+        assigned = longform[longform["assignment"] == 1.0]
+        assert "notpicked1" not in assigned["seatrade"].to_numpy()
+
+        wideform = wrangle_assignments_to_wideform(longform)
+        assert "notpicked1" not in wideform.to_numpy()
+
     def test_legacy_force_fill_is_infeasible(self):
         """allow_empty_sessions=False restores the hard floor: notpicked1 can't fill -> INFEASIBLE."""
         problem = SchedulingProblem(self._joined, self._setup)

--- a/tests/test_seatrades/test_solver.py
+++ b/tests/test_seatrades/test_solver.py
@@ -268,3 +268,51 @@ class TestStatusCodeMapping:
         solution = run(problem, config)
         # Infeasible should map to INFEASIBLE, not be swallowed as ERROR
         assert solution.status.state == SolverState.INFEASIBLE
+
+
+class TestConditionalMinCapacity:
+    """`campers_min` is a viability threshold, not a forced quota (issue #48).
+
+    A session may have either 0 campers (it doesn't run) or a count within
+    [campers_min, campers_max] (it runs). A seatrade nobody ranked simply drops.
+    """
+
+    # Four campers rank only pick1-pick4 (enough to fill both block pairs for
+    # everyone). notpicked1 has campers_min > 0 but nobody ranks it.
+    _joined = pd.DataFrame(
+        {
+            "cabin": ["Cabin1", "Cabin1", "Cabin2", "Cabin2"],
+            "camper": ["Alice", "Bob", "Carol", "Dave"],
+            "gender": ["F", "F", "M", "M"],
+            "seatrade_1": ["pick1", "pick2", "pick3", "pick4"],
+            "seatrade_2": ["pick2", "pick3", "pick4", "pick1"],
+            "seatrade_3": ["pick3", "pick4", "pick1", "pick2"],
+            "seatrade_4": ["pick4", "pick1", "pick2", "pick3"],
+        }
+    )
+    _setup = pd.DataFrame(
+        {
+            "seatrade": ["pick1", "pick2", "pick3", "pick4", "notpicked1"],
+            "campers_min": [0, 0, 0, 0, 2],
+            "campers_max": [10, 10, 10, 10, 10],
+        }
+    )
+
+    def test_unranked_session_drops_instead_of_infeasible(self):
+        """Default (conditional min): notpicked1's sessions drop to 0; solve is OPTIMAL."""
+        problem = SchedulingProblem(self._joined, self._setup)
+        config = OptimizationConfig(solver=pulp.apis.PULP_CBC_CMD(msg=0))
+        solution = run(problem, config)
+
+        assert solution.status.state == SolverState.OPTIMAL
+        notpicked_cols = [c for c in solution.assignments.columns if c.endswith("_notpicked1")]
+        assert notpicked_cols  # the columns exist...
+        assert solution.assignments[notpicked_cols].to_numpy().sum() == 0  # ...but hold no campers
+
+    def test_legacy_force_fill_is_infeasible(self):
+        """allow_empty_sessions=False restores the hard floor: notpicked1 can't fill -> INFEASIBLE."""
+        problem = SchedulingProblem(self._joined, self._setup)
+        config = OptimizationConfig(allow_empty_sessions=False, solver=pulp.apis.PULP_CBC_CMD(msg=0))
+        solution = run(problem, config)
+
+        assert solution.status.state == SolverState.INFEASIBLE


### PR DESCRIPTION
Closes #48.

## What

Makes `campers_min` a **conditional minimum per session** instead of a hard floor. A session now either **runs** (camper count in `[campers_min, campers_max]`) or **doesn't run** (0 campers) — nothing in between. This reframes `campers_min` as a *viability threshold* ("worth running only with N campers") and removes a class of spurious infeasibility where an unranked seatrade's minimum was force-filled.

## How

- **`config.py`** — add `OptimizationConfig.allow_empty_sessions: bool = True`. Default-on selects conditional-min; `False` restores the legacy hard floor. Not wired into the UI.
- **`problem.py`** — rewrite `_add_capacity_constraints` to gate both bounds on the existing per-session `seatrade_assignment` "running" indicator (`count >= min*running`, `count <= max*running`). No new variable; combined with the existing link constraint the indicator tracks occupancy both directions.
- **`CONTEXT.md`** — reword constraint #3 to a conditional minimum; add Decisions-Log #14.

Constraints-only — no objective term or penalty. Only *widens* the feasible region; with `campers_min = 0` it's a no-op.

## Tests (TDD, red→green)

- **Acceptance** (`test_solver.py`): campers rank only `pick1`–`pick4`; `notpicked1` has `campers_min > 0` and nobody ranks it. Default → `OPTIMAL` with 0 campers in `notpicked1`; `allow_empty_sessions=False` → `INFEASIBLE` (legacy force-fill).
- **Unit** (`test_problem.py`): `_add_capacity_constraints` updated for new signature + `Min_if_running`/`Max_if_running` names, with a legacy-path sibling asserting `More_than`/`Less_than`.
- **Guardrail**: single-seatrade `campers_min=2` tests stay `INFEASIBLE` (different reason); `campers_min=0` tests unchanged.

Full suite: 182 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)