### PR TITLE
feat(relationships): besties constraint, Friends tab, validation (#65)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,6 +81,10 @@ A social constraint between a pair of campers. Each relationship has:
 
 All relationship types are hard constraints — the solver must satisfy them or report infeasibility. Relationships are optional input; when absent, no relationship constraints are applied.
 
+**Implementation status (slice #65).** The schema, validation, Friends tab, and solver wiring are shared across all three types, but only **besties** is enforced by the solver so far. `friends` and `frenemies` rows validate and persist but are not yet constrained — enforcement (with auxiliary shared-session variables) lands in a follow-up slice.
+
+**Besties feasibility is checked at validation, not solve time.** A besties pair needs two identical sessions, so its members must share at least 2 preferred seatrades; `validate_relationships` rejects a besties pair that shares fewer (naming both campers) before the solver runs. The mock generator (`simulate_camper_relationships`) seeds a same-cabin pair sharing ≥2 preferences, so the default demo always solves.
+
 ### Assignment
 
 A mapping of a camper to a seatrade in a specific block. Each camper gets exactly 2 assignments per week (one per block).
@@ -134,7 +138,7 @@ flowchart LR
 ```
 1. User uploads CSVs or uses simulation → app/ calls seatrades.simulation (produces 3 DataFrames: camper identity, camper preferences, seatrade setup + optional relationships [#58])
 2. preferences.py validates (names match, seatrades exist in setup, relationship pairs valid [#58]) and joins 3 DataFrames → 2 (joined campers, seatrade setup) + validated relationships [#58]
-3. SchedulingProblem(joined_campers, seatrade_setup) → holds parsed domain state (relationships parameter [#58 planned])
+3. SchedulingProblem(joined_campers, seatrade_setup, relationships) → holds parsed domain state; maps besties pairs to internal camper_ids [#65]
 4. solver.run(problem, config) → calls problem.build(config) internally, returns AssignmentSolution (with SolverStatus inside)
 5. UI reads AssignmentSolution.status via @st.fragment, displays assignments
 6. `wrangle_assignments_to_longform(solution)` / `wrangle_assignments_to_wideform(longform_df)` → formatted DataFrames
@@ -157,7 +161,7 @@ The scheduler solves a mixed-integer linear programming problem with these const
 6. **Cabin max per seatrade** - Max k campers from same cabin in one seatrade (by default k=4)
 7. **Fleet balance** - Cabins split evenly between fleets
 8. **Gender balance** - Boys/girls cabins split evenly between fleets
-9. **Camper relationships** - Friends (share ≥1 session), besties (identical schedule), frenemies (share zero sessions). Hard constraints, optional input.
+9. **Camper relationships** - Friends (share ≥1 session), besties (identical schedule), frenemies (share zero sessions). Hard constraints, optional input. **Only besties is enforced so far (slice #65)**; friends/frenemies validate but are not yet constrained. Besties is implemented in `_add_besties_constraints` by equating the two campers' assignment variables across every block_seatrade — no auxiliary variables.
 
 ### Objective Goals (user-facing)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,9 +81,9 @@ A social constraint between a pair of campers. Each relationship has:
 
 All relationship types are hard constraints — the solver must satisfy them or report infeasibility. Relationships are optional input; when absent, no relationship constraints are applied.
 
-**Implementation status (slice #65).** The schema, validation, Friends tab, and solver wiring are shared across all three types, but only **besties** is enforced by the solver so far. `friends` and `frenemies` rows validate and persist but are not yet constrained — enforcement (with auxiliary shared-session variables) lands in a follow-up slice.
+**Implementation status (slice #66).** All three types are now enforced by the solver. Besties (slice #65) equates assignment variables; friends and frenemies (slice #66) use an auxiliary binary `y[c1, c2, s]` = AND(both campers in session `s`), linearized with standard AND constraints. Friends require `sum_s y >= 1` (share at least one session); frenemies require `sum_s y == 0` (share none). See `_session_overlap_vars`, `_add_friends_constraints`, `_add_frenemies_constraints` in `problem.py`.
 
-**Besties feasibility is checked at validation, not solve time.** A besties pair needs two identical sessions, so its members must share at least 2 preferred seatrades; `validate_relationships` rejects a besties pair that shares fewer (naming both campers) before the solver runs. The mock generator (`simulate_camper_relationships`) seeds a same-cabin pair sharing ≥2 preferences, so the default demo always solves.
+**Feasibility is checked at validation, not solve time.** A besties pair needs two identical sessions, so its members must share at least 2 preferred seatrades; a friends pair needs one shared session, so its members must share at least 1. `validate_relationships` rejects either pair that shares too few (naming both campers) before the solver runs. Frenemies has no such precondition — forcing overlap depends on global capacity/assignment, which is the out-of-scope solver-diagnostics case. The mock generator (`simulate_camper_relationships`) seeds one pair of each type on distinct campers — same-cabin for besties/friends, cross-cabin for frenemies — so the default demo always solves.
 
 ### Assignment
 
@@ -138,7 +138,7 @@ flowchart LR
 ```
 1. User uploads CSVs or uses simulation → app/ calls seatrades.simulation (produces 3 DataFrames: camper identity, camper preferences, seatrade setup + optional relationships [#58])
 2. preferences.py validates (names match, seatrades exist in setup, relationship pairs valid [#58]) and joins 3 DataFrames → 2 (joined campers, seatrade setup) + validated relationships [#58]
-3. SchedulingProblem(joined_campers, seatrade_setup, relationships) → holds parsed domain state; maps besties pairs to internal camper_ids [#65]
+3. SchedulingProblem(joined_campers, seatrade_setup, relationships) → holds parsed domain state; maps besties/friends/frenemies pairs to internal camper_ids [#65, #66]
 4. solver.run(problem, config) → calls problem.build(config) internally, returns AssignmentSolution (with SolverStatus inside)
 5. UI reads AssignmentSolution.status via @st.fragment, displays assignments
 6. `wrangle_assignments_to_longform(solution)` / `wrangle_assignments_to_wideform(longform_df)` → formatted DataFrames
@@ -161,7 +161,7 @@ The scheduler solves a mixed-integer linear programming problem with these const
 6. **Cabin max per seatrade** - Max k campers from same cabin in one seatrade (by default k=4)
 7. **Fleet balance** - Cabins split evenly between fleets
 8. **Gender balance** - Boys/girls cabins split evenly between fleets
-9. **Camper relationships** - Friends (share ≥1 session), besties (identical schedule), frenemies (share zero sessions). Hard constraints, optional input. **Only besties is enforced so far (slice #65)**; friends/frenemies validate but are not yet constrained. Besties is implemented in `_add_besties_constraints` by equating the two campers' assignment variables across every block_seatrade — no auxiliary variables.
+9. **Camper relationships** - Friends (share ≥1 session), besties (identical schedule), frenemies (share zero sessions). Hard constraints, optional input. **All three are enforced (besties slice #65, friends/frenemies slice #66).** Besties (`_add_besties_constraints`) equates the two campers' assignment variables across every block_seatrade — no auxiliary variables. Friends and frenemies share an auxiliary binary `y[c1, c2, s]` = AND(both in session `s`); friends require `sum_s y >= 1`, frenemies `sum_s y == 0`.
 
 ### Objective Goals (user-facing)
 
@@ -236,6 +236,8 @@ Resolved during grilling session 2026-05-05. Open questions marked with [OPEN].
 13. **Camper relationships are hard MILP constraints with a dedicated input DataFrame.** Schema: `(cabin_1, camper_1, cabin_2, camper_2, relationship)` with values `friends`, `besties`, `frenemies`. Uses composite keys matching existing domain model. Session = seatrade + fleet + block; all relationship constraints operate on sessions. Validation rejects self-pairs and duplicate pairs (regardless of order). Relationships are optional — no constraints by default. Diagnosing contradictory constraint chains causing infeasibility is future work. PRD: `docs/prd/camper-relationships.md`.
 
 14. **`campers_min` is a conditional minimum per session (issue #48).** A session may have either 0 campers (it doesn't run) or a count within `[campers_min, campers_max]` (it runs) — nothing in between. This reframes `campers_min` as a *viability threshold* ("worth running only with N campers") rather than a forced quota, and removes a class of spurious infeasibility where an unranked seatrade's floor was force-filled. Constraints-only — no objective term or penalty; whether a session empties is still driven by the existing objective (notably `sparsity_weight`). Reuses the existing per-session `seatrade_assignment` indicator (the "session runs" binary) — no new variable. Both bounds are gated on that indicator in `_add_capacity_constraints`. Default-on via `OptimizationConfig.allow_empty_sessions` (not exposed in the UI); setting it `False` restores the legacy hard floor. Only *widens* the feasible region — never makes a feasible problem infeasible; with `campers_min = 0` it is a no-op.
+
+15. **Friends and frenemies are enforced via a shared session-overlap auxiliary variable (slice #66).** Both reuse one binary `y[c1, c2, s]` = AND(camper c1 in session `s`, camper c2 in session `s`), linearized with the standard AND constraints (`y <= x1`, `y <= x2`, `y >= x1 + x2 - 1`) in `_session_overlap_vars`. Friends then require `sum_s y >= 1` (share at least one session); frenemies require `sum_s y == 0` (share none). Besties keeps its simpler variable-equality formulation (no aux var). Friends gain a pre-solve feasibility check mirroring besties: a friends pair sharing 0 preferred seatrades is rejected at validation (`FRIENDS_MIN_SHARED_SEATRADES = 1`), since they could never co-occupy a session. Frenemies has no cheap provable precondition (forcing overlap depends on global capacity/assignment), so it is left to solve-time infeasibility — the out-of-scope diagnostics case from item 13.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The scheduling captain spends dozens of hours manually assigning hundreds of cam
 
 ## How to Use
 
-The app has four tabs:
+The app has five tabs:
 
 ### 1. Assignments
 View the optimized results. The app comes pre-loaded with demo data so you can immediately see the optimizer in action. Results update automatically when configuration changes:
@@ -40,7 +40,14 @@ Configure the campers and their preferences. Upload a CSV or use the built-in si
 - Gender
 - Four seatrade preferences (required)
 
-### 4. Optimization Setup
+### 4. Friends
+Pair up campers with a relationship. Type rows directly in the grid or upload a CSV:
+- **Besties** — the pair gets an identical schedule (enforced now)
+- **Friends** / **frenemies** — saved and validated, but not yet enforced
+
+A besties pair must share at least two preferred seatrades; the app flags an infeasible pair before you optimize.
+
+### 5. Optimization Setup
 Adjust how the optimizer balances competing priorities:
 - Preference weight (how much to prioritize camper choices)
 - Cabin weight (how much to keep cabin groups together)

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 
 from app.tabs.assignments_tab import AssignmentsTab
 from app.tabs.campers_tab import CamperSimulationConfigTab, _update_camper_simulation_config
+from app.tabs.friends_tab import FriendsTab
 from app.tabs.optimization_config_tab import (
     OptimizationConfigForm,
     _update_optimization_config,
@@ -15,6 +16,7 @@ from seatrades.preferences import join_and_validate
 from seatrades.simulation import (
     simulate_camper_identity,
     simulate_camper_preferences,
+    simulate_camper_relationships,
     simulate_seatrade_preferences,
 )
 
@@ -31,12 +33,14 @@ def main():
         assignments_tab,
         seatrades_tab,
         camper_pref_tab,
+        friends_tab,
         optimization_config_tab,
     ) = st.tabs(
         [
             ":material/date_range: Assignments",
             ":material/camping: Seatrade Setup",
             ":material/child_care: Camper Setup",
+            ":material/diversity_3: Friends",
             ":material/tune: Scheduling Setup",
         ]
     )
@@ -46,6 +50,8 @@ def main():
         SeatradeSimulationConfigTab().generate()
     with camper_pref_tab:
         CamperSimulationConfigTab().generate()
+    with friends_tab:
+        FriendsTab().generate()
     with optimization_config_tab:
         st.subheader("Scheduling Setup")
         OptimizationConfigForm().generate()
@@ -72,12 +78,19 @@ def _initial_page_setup():
         st.session_state["camper_preferences"] = simulate_camper_preferences(
             identity_df, st.session_state["seatrade_preferences"]
         )
+    # Seed a feasible mock besties pair so relationships are demoable out of the box.
+    if "camper_relationships" not in st.session_state:
+        st.session_state["camper_relationships"] = simulate_camper_relationships(
+            st.session_state["camper_identity"],
+            st.session_state["camper_preferences"],
+        )
     # cabin_camper_prefs is the joined result used by Seatrades
     if "cabin_camper_prefs" not in st.session_state:
-        joined_campers, _seatrade_setup = join_and_validate(
+        joined_campers, _seatrade_setup, _relationships = join_and_validate(
             st.session_state["camper_identity"],
             st.session_state["camper_preferences"],
             st.session_state["seatrade_preferences"],
+            st.session_state["camper_relationships"],
         )
         st.session_state["cabin_camper_prefs"] = joined_campers
 

--- a/app/components.py
+++ b/app/components.py
@@ -32,12 +32,15 @@ def try_join_and_validate():
     identity = st.session_state.get("camper_identity")
     preferences = st.session_state.get("camper_preferences")
     seatrades = st.session_state.get("seatrade_preferences")
+    relationships = st.session_state.get("camper_relationships")
 
     if identity is None or preferences is None or seatrades is None:
         return
 
     try:
-        joined_campers, seatrade_setup = join_and_validate(identity, preferences, seatrades)
+        joined_campers, _seatrade_setup, _relationships = join_and_validate(
+            identity, preferences, seatrades, relationships
+        )
         st.session_state["cabin_camper_prefs"] = joined_campers
     except ValidationError as e:
         show_validation_error("Cross-reference Validation", e)

--- a/app/tabs/assignments_tab.py
+++ b/app/tabs/assignments_tab.py
@@ -130,13 +130,16 @@ def _assign_seatrades(
     identity = st.session_state.get("camper_identity")
     camper_prefs = st.session_state.get("camper_preferences")
     seatrade_prefs = st.session_state.get("seatrade_preferences")
+    relationships = st.session_state.get("camper_relationships")
 
     if identity is None or camper_prefs is None or seatrade_prefs is None:
         st.toast("Missing camper or seatrade data. Upload or simulate first.", icon="🚨")
         return
 
     try:
-        joined_campers, seatrade_setup = join_and_validate(identity, camper_prefs, seatrade_prefs)
+        joined_campers, seatrade_setup, validated_relationships = join_and_validate(
+            identity, camper_prefs, seatrade_prefs, relationships
+        )
     except ValidationError as e:
         st.toast("Cross-reference validation failed.", icon="🚨")
         with st.popover("Validation errors. Click for details.", icon="🚨"):
@@ -146,7 +149,7 @@ def _assign_seatrades(
 
     st.session_state["cabin_camper_prefs"] = joined_campers
     st.toast("Beginning Seatrade Optimization.")
-    problem = SchedulingProblem(joined_campers, seatrade_setup)
+    problem = SchedulingProblem(joined_campers, seatrade_setup, relationships=validated_relationships)
     result_container: dict[str, AssignmentSolution] = {}
     with st.status("Setting up the optimization…") as status:
         # CAUTION: Does not actually stop the solver subthread which will keep running.

--- a/app/tabs/campers_tab.py
+++ b/app/tabs/campers_tab.py
@@ -6,7 +6,12 @@ import streamlit as st
 from app.components import clear_optimization_results, show_validation_error, try_join_and_validate
 from seatrades.config import CamperIdentity, CamperPreferences, CamperSimulationConfig
 from seatrades.preferences import ValidationError, join_and_validate, read_csv_for_schema, validate_schema
-from seatrades.simulation import ALL_CABIN_DICT, simulate_camper_identity, simulate_camper_preferences
+from seatrades.simulation import (
+    ALL_CABIN_DICT,
+    simulate_camper_identity,
+    simulate_camper_preferences,
+    simulate_camper_relationships,
+)
 
 
 def _update_camper_simulation_config(camper_simulation_config: CamperSimulationConfig):
@@ -24,7 +29,8 @@ def _update_camper_simulation_config(camper_simulation_config: CamperSimulationC
         st.toast(f"Updating Camper Simulation Configuration.\n\n{camper_simulation_config}")
     st.session_state["camper_simulation_config"] = camper_simulation_config
     clear_optimization_results()
-    for key in ("camper_identity", "camper_preferences"):
+    # Relationships reference specific campers; drop them so they're re-seeded for the new roster.
+    for key in ("camper_identity", "camper_preferences", "camper_relationships"):
         if key in st.session_state:
             del st.session_state[key]
 
@@ -147,13 +153,17 @@ def _simulate_campers(camper_simulation_config: CamperSimulationConfig):
 
     identity_df = simulate_camper_identity(camper_simulation_config)
     preferences_df = simulate_camper_preferences(identity_df, seatrade_prefs)
+    relationships_df = simulate_camper_relationships(identity_df, preferences_df)
 
     st.session_state["camper_identity"] = identity_df
     st.session_state["camper_preferences"] = preferences_df
+    st.session_state["camper_relationships"] = relationships_df
     clear_optimization_results()
 
     try:
-        joined_campers, seatrade_setup = join_and_validate(identity_df, preferences_df, seatrade_prefs)
+        joined_campers, _seatrade_setup, _relationships = join_and_validate(
+            identity_df, preferences_df, seatrade_prefs, relationships_df
+        )
         st.session_state["cabin_camper_prefs"] = joined_campers
     except ValidationError as e:
         show_validation_error("Cross-reference Validation", e)

--- a/app/tabs/friends_tab.py
+++ b/app/tabs/friends_tab.py
@@ -11,14 +11,12 @@ import streamlit as st
 
 from app.components import clear_optimization_results, show_validation_error
 from seatrades.config import RELATIONSHIP_TYPES, CamperRelationships
-from seatrades.preferences import ValidationError, read_csv_for_schema, validate_relationships
-
-_RELATIONSHIP_COLUMNS = ["cabin_1", "camper_1", "cabin_2", "camper_2", "relationship"]
-
-
-def empty_relationships() -> pd.DataFrame:
-    """An empty relationships grid with the right columns and dtypes."""
-    return pd.DataFrame({col: pd.Series(dtype="object") for col in _RELATIONSHIP_COLUMNS})
+from seatrades.preferences import (
+    ValidationError,
+    empty_relationships,
+    read_csv_for_schema,
+    validate_relationships,
+)
 
 
 class FriendsTab:

--- a/app/tabs/friends_tab.py
+++ b/app/tabs/friends_tab.py
@@ -1,0 +1,83 @@
+"""Friends tab — define camper relationships (friends / besties / frenemies).
+
+Primary input is an editable grid: a captain types (cabin, camper, cabin, camper,
+relationship) rows directly. A CSV upload is an optional bulk-entry convenience that
+seeds the grid. Besties are enforced by the solver this slice; friends and frenemies
+are saved and validated but not yet enforced.
+"""
+
+import pandas as pd
+import streamlit as st
+
+from app.components import clear_optimization_results, show_validation_error
+from seatrades.config import RELATIONSHIP_TYPES, CamperRelationships
+from seatrades.preferences import ValidationError, read_csv_for_schema, validate_relationships
+
+_RELATIONSHIP_COLUMNS = ["cabin_1", "camper_1", "cabin_2", "camper_2", "relationship"]
+
+
+def empty_relationships() -> pd.DataFrame:
+    """An empty relationships grid with the right columns and dtypes."""
+    return pd.DataFrame({col: pd.Series(dtype="object") for col in _RELATIONSHIP_COLUMNS})
+
+
+class FriendsTab:
+    """Tab content for defining camper relationships."""
+
+    def generate(self) -> None:
+        st.subheader("Friends")
+        st.caption(
+            "Pair up campers. **Besties** share an identical schedule (enforced now). "
+            "**Friends** and **frenemies** are saved for later. Type rows directly, or "
+            "upload a CSV to fill the grid."
+        )
+
+        uploaded = st.file_uploader(
+            label="Upload relationships (cabin_1, camper_1, cabin_2, camper_2, relationship).",
+            type="csv",
+            help="Optional. Seeds the grid below — you can also type rows in directly.",
+            key="relationships_uploader",
+        )
+        if uploaded:
+            try:
+                data = read_csv_for_schema(uploaded, CamperRelationships)
+            except ValidationError as e:
+                show_validation_error("Camper Relationships", e)
+            else:
+                _update_relationships(data)
+
+        current = st.session_state.get("camper_relationships")
+        if current is None or current.empty:
+            current = empty_relationships()
+
+        edited = st.data_editor(
+            current,
+            num_rows="dynamic",
+            key="relationships_editor",
+            use_container_width=True,
+            column_config={
+                "relationship": st.column_config.SelectboxColumn(
+                    "relationship",
+                    options=RELATIONSHIP_TYPES,
+                    required=True,
+                    help="One of friends, besties, frenemies.",
+                ),
+            },
+        )
+        if not edited.reset_index(drop=True).equals(current.reset_index(drop=True)):
+            _update_relationships(edited)
+
+
+def _update_relationships(relationships: pd.DataFrame) -> None:
+    """Persist the edited grid and surface validation feedback against current campers."""
+    st.session_state["camper_relationships"] = relationships.reset_index(drop=True)
+    clear_optimization_results()
+
+    joined = st.session_state.get("cabin_camper_prefs")
+    if joined is None or relationships.empty:
+        return
+    try:
+        validate_relationships(relationships, joined, "Camper Relationships")
+        st.toast("Updating Camper Relationships.")
+    except ValidationError as e:
+        show_validation_error("Camper Relationships", e)

--- a/app/tabs/friends_tab.py
+++ b/app/tabs/friends_tab.py
@@ -2,8 +2,8 @@
 
 Primary input is an editable grid: a captain types (cabin, camper, cabin, camper,
 relationship) rows directly. A CSV upload is an optional bulk-entry convenience that
-seeds the grid. Besties are enforced by the solver this slice; friends and frenemies
-are saved and validated but not yet enforced.
+seeds the grid. All three relationship types are enforced by the solver as hard
+constraints.
 """
 
 import pandas as pd
@@ -24,11 +24,27 @@ class FriendsTab:
 
     def generate(self) -> None:
         st.subheader("Friends")
-        st.caption(
-            "Pair up campers. **Besties** share an identical schedule (enforced now). "
-            "**Friends** and **frenemies** are saved for later. Type rows directly, or "
-            "upload a CSV to fill the grid."
+        st.markdown(
+            "Pair up campers whose social ties should shape the schedule. Each row links two "
+            "campers — a `(cabin, camper)` and another `(cabin, camper)` — plus a relationship "
+            "type. Type rows directly in the grid below, or upload a CSV to fill it. Every "
+            "relationship is a **hard rule**: the optimizer must satisfy all of them, or it "
+            "reports that no schedule is possible."
         )
+        with st.expander("What do friends, besties, and frenemies mean?"):
+            st.markdown(
+                "- **Friends** — the pair shares **at least one session**: the same seatrade, in "
+                "the same fleet and block (so they're together at least once during the week). "
+                "_Needs at least one preferred seatrade in common, or it can't be honoured._\n"
+                "- **Besties** — the pair gets an **identical schedule**: the same seatrades in "
+                "the same blocks for the whole week (this also puts them in the same fleet). "
+                "_Needs at least two preferred seatrades in common._\n"
+                "- **Frenemies** — the pair shares **no session**: they are never placed in the "
+                "same seatrade at the same time.\n\n"
+                "Order within a pair doesn't matter, and each pair may appear only once. Besties "
+                "or friends that don't share enough preferred seatrades are flagged here, before "
+                "you optimize, so you can fix typos instead of waiting on a failed solve."
+            )
 
         uploaded = st.file_uploader(
             label="Upload relationships (cabin_1, camper_1, cabin_2, camper_2, relationship).",
@@ -58,7 +74,9 @@ class FriendsTab:
                     "relationship",
                     options=RELATIONSHIP_TYPES,
                     required=True,
-                    help="One of friends, besties, frenemies.",
+                    help=(
+                        "friends = share ≥1 session · besties = identical schedule · frenemies = never share a session."
+                    ),
                 ),
             },
         )

--- a/app/tabs/friends_tab.py
+++ b/app/tabs/friends_tab.py
@@ -25,18 +25,18 @@ class FriendsTab:
     def generate(self) -> None:
         st.subheader("Friends")
         st.markdown(
-            "Pair up campers whose social ties should shape the schedule. Each row links two "
-            "campers — a `(cabin, camper)` and another `(cabin, camper)` — plus a relationship "
-            "type. Type rows directly in the grid below, or upload a CSV to fill it. Every "
+            "Pair up campers if you want to honor sepcific friendships beyond the 'cabin togetherness' scores"
+            "in the scheduling setup. Each row links two "
+            "campers plus a relationship type. Type rows directly in the grid below, or upload a CSV to fill it. Every "
             "relationship is a **hard rule**: the optimizer must satisfy all of them, or it "
             "reports that no schedule is possible."
         )
-        with st.expander("What do friends, besties, and frenemies mean?"):
+        with st.expander("What relationships are available? (Friends, Besties, Frenemies)"):
             st.markdown(
-                "- **Friends** — the pair shares **at least one session**: the same seatrade, in "
+                "- **Friends** — the pair shares **at least one seatrade session**: the same seatrade, in "
                 "the same fleet and block (so they're together at least once during the week). "
                 "_Needs at least one preferred seatrade in common, or it can't be honoured._\n"
-                "- **Besties** — the pair gets an **identical schedule**: the same seatrades in "
+                "- **Besties** — the pair gets an **identical seatrade schedule**: the same seatrades in "
                 "the same blocks for the whole week (this also puts them in the same fleet). "
                 "_Needs at least two preferred seatrades in common._\n"
                 "- **Frenemies** — the pair shares **no session**: they are never placed in the "

--- a/app/tabs/friends_tab.py
+++ b/app/tabs/friends_tab.py
@@ -38,11 +38,11 @@ class FriendsTab:
         )
         if uploaded:
             try:
-                data = read_csv_for_schema(uploaded, CamperRelationships)
+                uploaded_relationships = read_csv_for_schema(uploaded, CamperRelationships)
             except ValidationError as e:
                 show_validation_error("Camper Relationships", e)
             else:
-                _update_relationships(data)
+                _update_relationships(uploaded_relationships)
 
         current = st.session_state.get("camper_relationships")
         if current is None or current.empty:

--- a/seatrades/config.py
+++ b/seatrades/config.py
@@ -70,6 +70,23 @@ class CamperIdentity(DataFrameModel):
     gender: str = Field(ignore_na=False)
 
 
+RELATIONSHIP_TYPES = ["friends", "besties", "frenemies"]
+
+
+class CamperRelationships(DataFrameModel):
+    """Camper social relationships — pairs of campers with a relationship type.
+
+    Each pair uses (cabin, camper) composite keys to match the camper identity
+    domain model. ``relationship`` is one of friends, besties, or frenemies.
+    """
+
+    cabin_1: str = Field(ignore_na=False)
+    camper_1: str = Field(ignore_na=False)
+    cabin_2: str = Field(ignore_na=False)
+    camper_2: str = Field(ignore_na=False)
+    relationship: str = Field(isin=RELATIONSHIP_TYPES, ignore_na=False)
+
+
 class CamperPreferences(DataFrameModel):
     """Camper seatrade preferences — ranked choices."""
 

--- a/seatrades/config.py
+++ b/seatrades/config.py
@@ -76,6 +76,10 @@ RELATIONSHIP_TYPES = ["friends", "besties", "frenemies"]
 # this many preferred seatrades for the identical-schedule constraint to stay feasible.
 BESTIES_MIN_SHARED_SEATRADES = 2
 
+# A friends pair needs one shared session, so its members must share at least this
+# many preferred seatrades to have any session they could both occupy.
+FRIENDS_MIN_SHARED_SEATRADES = 1
+
 
 class CamperRelationships(DataFrameModel):
     """Camper social relationships — pairs of campers with a relationship type.

--- a/seatrades/config.py
+++ b/seatrades/config.py
@@ -72,6 +72,10 @@ class CamperIdentity(DataFrameModel):
 
 RELATIONSHIP_TYPES = ["friends", "besties", "frenemies"]
 
+# A besties pair needs two identical sessions, so its members must share at least
+# this many preferred seatrades for the identical-schedule constraint to stay feasible.
+BESTIES_MIN_SHARED_SEATRADES = 2
+
 
 class CamperRelationships(DataFrameModel):
     """Camper social relationships — pairs of campers with a relationship type.

--- a/seatrades/preferences.py
+++ b/seatrades/preferences.py
@@ -18,6 +18,7 @@ from pandera import DataFrameModel
 from pandera.errors import SchemaError, SchemaErrors
 
 from seatrades.config import (
+    BESTIES_MIN_SHARED_SEATRADES,
     PREF_COLS,
     CamperIdentity,
     CamperPreferences,
@@ -25,7 +26,12 @@ from seatrades.config import (
     SeatradesConfig,
 )
 
-_BESTIES_MIN_SHARED_SEATRADES = 2
+
+def empty_relationships() -> pd.DataFrame:
+    """An empty, schema-valid CamperRelationships frame (columns derived from the schema)."""
+    columns = CamperRelationships.to_schema().columns.keys()
+    empty = pd.DataFrame({col: pd.Series(dtype="object") for col in columns})
+    return CamperRelationships.validate(empty)  # type: ignore[return-value]
 
 
 class ValidationError(Exception):
@@ -158,6 +164,7 @@ def validate_relationships(
             pair = frozenset({camper_1, camper_2})
             if pair in seen_pairs:
                 errors.append(f"Row {row.Index}: duplicate pair {camper_1} & {camper_2} (order does not matter).")
+                continue
             seen_pairs.add(pair)
 
             unknown = [c for c in (camper_1, camper_2) if c not in known_campers]
@@ -168,10 +175,10 @@ def validate_relationships(
 
             if row.relationship == "besties":
                 shared = prefs_by_camper[camper_1] & prefs_by_camper[camper_2]
-                if len(shared) < _BESTIES_MIN_SHARED_SEATRADES:
+                if len(shared) < BESTIES_MIN_SHARED_SEATRADES:
                     errors.append(
                         f"Row {row.Index}: besties pair {camper_1} & {camper_2} share fewer than "
-                        f"{_BESTIES_MIN_SHARED_SEATRADES} preferred seatrades — no identical schedule is possible."
+                        f"{BESTIES_MIN_SHARED_SEATRADES} preferred seatrades — no identical schedule is possible."
                     )
 
     if errors:

--- a/seatrades/preferences.py
+++ b/seatrades/preferences.py
@@ -19,6 +19,7 @@ from pandera.errors import SchemaError, SchemaErrors
 
 from seatrades.config import (
     BESTIES_MIN_SHARED_SEATRADES,
+    FRIENDS_MIN_SHARED_SEATRADES,
     PREF_COLS,
     CamperIdentity,
     CamperPreferences,
@@ -132,9 +133,10 @@ def validate_relationships(
 
     Checks (collect-all-errors-then-raise, like join_and_validate):
     schema, self-pairs, order-insensitive duplicate pairs, that both campers
-    exist in joined_campers, and that besties pairs share enough preferences to
-    have a feasible identical schedule. joined_campers carries seatrade_1..4 so
-    the besties feasibility check can run before solver time.
+    exist in joined_campers, that besties pairs share enough preferences to have
+    a feasible identical schedule, and that friends pairs share at least one
+    preferred seatrade so a shared session is possible. joined_campers carries
+    seatrade_1..4 so these feasibility checks can run before solver time.
 
     Returns the validated relationships DataFrame.
     """
@@ -179,6 +181,13 @@ def validate_relationships(
                     errors.append(
                         f"Row {row.Index}: besties pair {camper_1} & {camper_2} share fewer than "
                         f"{BESTIES_MIN_SHARED_SEATRADES} preferred seatrades — no identical schedule is possible."
+                    )
+            elif row.relationship == "friends":
+                shared = prefs_by_camper[camper_1] & prefs_by_camper[camper_2]
+                if len(shared) < FRIENDS_MIN_SHARED_SEATRADES:
+                    errors.append(
+                        f"Row {row.Index}: friends pair {camper_1} & {camper_2} share no preferred "
+                        f"seatrades — no shared session is possible."
                     )
 
     if errors:

--- a/seatrades/preferences.py
+++ b/seatrades/preferences.py
@@ -9,13 +9,23 @@ Pandera mypy suppressions:
 Revisit if pandera mypy plugin improves or pandas-stubs adds DataFrameModel support.
 """
 
+from __future__ import annotations
+
 import re
 
 import pandas as pd
 from pandera import DataFrameModel
 from pandera.errors import SchemaError, SchemaErrors
 
-from seatrades.config import PREF_COLS, CamperIdentity, CamperPreferences, SeatradesConfig
+from seatrades.config import (
+    PREF_COLS,
+    CamperIdentity,
+    CamperPreferences,
+    CamperRelationships,
+    SeatradesConfig,
+)
+
+_BESTIES_MIN_SHARED_SEATRADES = 2
 
 
 class ValidationError(Exception):
@@ -107,19 +117,86 @@ def read_csv_for_schema(file_like, schema_class: type[DataFrameModel], **kwargs)
     return df[columns]
 
 
+def validate_relationships(
+    relationships_df: pd.DataFrame,
+    joined_campers: pd.DataFrame,
+    label: str = "Camper Relationships",
+) -> pd.DataFrame:
+    """Validate camper relationship pairs against the joined campers.
+
+    Checks (collect-all-errors-then-raise, like join_and_validate):
+    schema, self-pairs, order-insensitive duplicate pairs, that both campers
+    exist in joined_campers, and that besties pairs share enough preferences to
+    have a feasible identical schedule. joined_campers carries seatrade_1..4 so
+    the besties feasibility check can run before solver time.
+
+    Returns the validated relationships DataFrame.
+    """
+    errors: list[str] = []
+
+    validated: pd.DataFrame | None = None
+    try:
+        validated = validate_schema(CamperRelationships, relationships_df, label)
+    except ValidationError as e:
+        errors.extend(e.errors)
+
+    # Row-level checks only once the schema (columns, types, non-null) is sound.
+    if not errors:
+        assert validated is not None
+        prefs_by_camper = {
+            (row.cabin, row.camper): {getattr(row, col) for col in PREF_COLS}
+            for row in joined_campers.itertuples(index=False)
+        }
+        known_campers = set(prefs_by_camper)
+        seen_pairs: set[frozenset[tuple[str, str]]] = set()
+        for row in validated.itertuples(index=True):
+            camper_1 = (str(row.cabin_1), str(row.camper_1))
+            camper_2 = (str(row.cabin_2), str(row.camper_2))
+            if camper_1 == camper_2:
+                errors.append(f"Row {row.Index}: camper {camper_1} cannot have a relationship with itself.")
+                continue
+            pair = frozenset({camper_1, camper_2})
+            if pair in seen_pairs:
+                errors.append(f"Row {row.Index}: duplicate pair {camper_1} & {camper_2} (order does not matter).")
+            seen_pairs.add(pair)
+
+            unknown = [c for c in (camper_1, camper_2) if c not in known_campers]
+            if unknown:
+                named = " and ".join(str(c) for c in unknown)
+                errors.append(f"Row {row.Index}: {named} is not a known camper.")
+                continue
+
+            if row.relationship == "besties":
+                shared = prefs_by_camper[camper_1] & prefs_by_camper[camper_2]
+                if len(shared) < _BESTIES_MIN_SHARED_SEATRADES:
+                    errors.append(
+                        f"Row {row.Index}: besties pair {camper_1} & {camper_2} share fewer than "
+                        f"{_BESTIES_MIN_SHARED_SEATRADES} preferred seatrades — no identical schedule is possible."
+                    )
+
+    if errors:
+        raise ValidationError(errors)
+
+    return validated  # type: ignore[return-value]
+
+
 def join_and_validate(
     identity_df: pd.DataFrame,
     preferences_df: pd.DataFrame,
     seatrade_df: pd.DataFrame,
-) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Validate cross-references and join 3 DataFrames into 2.
+    relationships_df: pd.DataFrame | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame | None]:
+    """Validate cross-references and join 3 DataFrames into 2 (+ optional relationships).
 
-    Takes camper identity, camper preferences, and seatrade config DataFrames.
-    Validates that camper names match between identity and preferences, and
-    that all seatrade names in preferences exist in the seatrade config.
+    Takes camper identity, camper preferences, seatrade config, and optionally
+    camper relationships DataFrames. Validates that camper names match between
+    identity and preferences, that all seatrade names in preferences exist in the
+    seatrade config, and (when provided) that relationships reference known campers
+    and are feasible.
 
-    Returns (joined_campers, seatrade_setup) where joined_campers has columns:
-    cabin, camper, gender, seatrade_1..4.
+    Returns (joined_campers, seatrade_setup, validated_relationships) where
+    joined_campers has columns cabin, camper, gender, seatrade_1..4 and
+    validated_relationships is None when no relationships are given (absent or empty).
     """
     errors: list[str] = []
 
@@ -170,9 +247,19 @@ def join_and_validate(
             invalid = ", ".join(sorted(invalid_seatrades))
             errors.append(f"Seatrades in preferences but not in seatrade config: {invalid}")
 
+    # Relationships are validated against the joined campers, but only once the
+    # identity/preferences data is internally consistent (the join is meaningful).
+    joined: pd.DataFrame | None = None
+    validated_relationships: pd.DataFrame | None = None
+    if not errors:
+        joined = identity_validated.merge(preferences_validated, on="camper")  # type: ignore[union-attr, arg-type]
+        if relationships_df is not None and not relationships_df.empty:
+            try:
+                validated_relationships = validate_relationships(relationships_df, joined, "Camper Relationships")
+            except ValidationError as e:
+                errors.extend(e.errors)
+
     if errors:
         raise ValidationError(errors)
 
-    # At this point all validated DataFrames are non-None (guaranteed by the raise above).
-    joined = identity_validated.merge(preferences_validated, on="camper")  # type: ignore[union-attr, arg-type]
-    return joined, seatrade_validated  # type: ignore[return-value]
+    return joined, seatrade_validated, validated_relationships  # type: ignore[return-value]

--- a/seatrades/preferences.py
+++ b/seatrades/preferences.py
@@ -186,8 +186,8 @@ def validate_relationships(
                 shared = prefs_by_camper[camper_1] & prefs_by_camper[camper_2]
                 if len(shared) < FRIENDS_MIN_SHARED_SEATRADES:
                     errors.append(
-                        f"Row {row.Index}: friends pair {camper_1} & {camper_2} share no preferred "
-                        f"seatrades — no shared session is possible."
+                        f"Row {row.Index}: friends pair {camper_1} & {camper_2} share fewer than "
+                        f"{FRIENDS_MIN_SHARED_SEATRADES} preferred seatrades — no shared session is possible."
                     )
 
     if errors:

--- a/seatrades/problem.py
+++ b/seatrades/problem.py
@@ -65,16 +65,22 @@ class SchedulingProblem:
             (str(row.cabin), str(row.camper)): int(row.camper_id)  # type: ignore[arg-type]
             for row in joined_campers.itertuples(index=False)
         }
-        self.besties_pairs: list[tuple[int, int]] = []
-        if relationships is not None and not relationships.empty:
-            besties = relationships[relationships["relationship"] == "besties"]
-            for row in besties.itertuples(index=False):
-                self.besties_pairs.append(
-                    (
-                        camper_id_by_key[(str(row.cabin_1), str(row.camper_1))],
-                        camper_id_by_key[(str(row.cabin_2), str(row.camper_2))],
-                    )
+
+        def pairs_for(relationship: str) -> list[tuple[int, int]]:
+            if relationships is None or relationships.empty:
+                return []
+            rows = relationships[relationships["relationship"] == relationship]
+            return [
+                (
+                    camper_id_by_key[(str(row.cabin_1), str(row.camper_1))],
+                    camper_id_by_key[(str(row.cabin_2), str(row.camper_2))],
                 )
+                for row in rows.itertuples(index=False)
+            ]
+
+        self.besties_pairs = pairs_for("besties")
+        self.friends_pairs = pairs_for("friends")
+        self.frenemies_pairs = pairs_for("frenemies")
 
     def build(self, config: OptimizationConfig) -> pulp.LpProblem:
         """Build an unsolved LpProblem from domain data and optimization config.
@@ -123,6 +129,8 @@ class SchedulingProblem:
         self._add_top2_guarantee_constraints(problem, camper_assignments)
         self._add_cabin_max_constraints(problem, camper_assignments)
         self._add_besties_constraints(problem, camper_assignments)
+        self._add_friends_constraints(problem, camper_assignments)
+        self._add_frenemies_constraints(problem, camper_assignments)
         self._add_fleet_assignment_constraints(problem, fleet_assignment)
         self._add_fleet_balance_constraints(problem, fleet_assignment)
         self._add_gender_balance_constraints(problem, fleet_assignment)
@@ -253,6 +261,35 @@ class SchedulingProblem:
                     camper_assignments[c1][s] == camper_assignments[c2][s],
                     f"besties_{c1}_{c2}_{s}",
                 )
+
+    def _session_overlap_vars(
+        self, problem: pulp.LpProblem, camper_assignments: VarDict, c1: int, c2: int
+    ) -> dict[str, pulp.LpVariable]:
+        """Auxiliary binary y[s] = AND(c1 in s, c2 in s), one per session.
+
+        Linearized with the standard AND constraints so y[s] is 1 exactly when both
+        campers occupy session s. Friends and frenemies both build on these.
+        """
+        overlap: dict[str, pulp.LpVariable] = {}
+        for s in self.seatrades_full:
+            y = pulp.LpVariable(f"overlap_{c1}_{c2}_{s}", cat=pulp.LpBinary)
+            problem += y <= camper_assignments[c1][s]
+            problem += y <= camper_assignments[c2][s]
+            problem += y >= camper_assignments[c1][s] + camper_assignments[c2][s] - 1
+            overlap[s] = y
+        return overlap
+
+    def _add_friends_constraints(self, problem: pulp.LpProblem, camper_assignments: VarDict) -> None:
+        """Friends pairs share at least one session."""
+        for c1, c2 in self.friends_pairs:
+            overlap = self._session_overlap_vars(problem, camper_assignments, c1, c2)
+            problem += (pulp.lpSum(overlap.values()) >= 1, f"friends_{c1}_{c2}")
+
+    def _add_frenemies_constraints(self, problem: pulp.LpProblem, camper_assignments: VarDict) -> None:
+        """Frenemies pairs share no session."""
+        for c1, c2 in self.frenemies_pairs:
+            overlap = self._session_overlap_vars(problem, camper_assignments, c1, c2)
+            problem += (pulp.lpSum(overlap.values()) == 0, f"frenemies_{c1}_{c2}")
 
     def _add_fleet_assignment_constraints(self, problem: pulp.LpProblem, fleet_assignment: VarDict) -> None:
         """Each cabin is assigned to exactly one fleet per block pair."""

--- a/seatrades/problem.py
+++ b/seatrades/problem.py
@@ -1,6 +1,6 @@
 """SchedulingProblem — builds PuLP model from domain data."""
 
-from typing import Hashable
+from typing import Hashable, Optional
 
 import pandas as pd
 import pulp
@@ -32,7 +32,12 @@ class SchedulingProblem:
     VarDict = dict[Hashable, dict[str, pulp.LpVariable]]
     _CABIN_MAX_PER_SEATRADE = 4
 
-    def __init__(self, joined_campers: pd.DataFrame, seatrade_setup: pd.DataFrame):
+    def __init__(
+        self,
+        joined_campers: pd.DataFrame,
+        seatrade_setup: pd.DataFrame,
+        relationships: Optional[pd.DataFrame] = None,
+    ):
         # Campers are identified internally by zero-indexed integer IDs (row
         # position), never by name. IDs are unique by construction, so they key
         # PuLP variables without the name-collision hack and never leak to output.
@@ -53,6 +58,23 @@ class SchedulingProblem:
         self.seatrades = seatrade_setup["seatrade"]
         self.fleets = BLOCKS
         self.seatrades_full = [f"{block}_{seatrade}" for block in self.fleets for seatrade in self.seatrades]
+
+        # Relationships reference campers by (cabin, camper); map them to integer IDs
+        # so constraints can be expressed over the camper_assignments variables.
+        camper_id_by_key: dict[tuple[str, str], int] = {
+            (str(row.cabin), str(row.camper)): int(row.camper_id)  # type: ignore[arg-type]
+            for row in joined_campers.itertuples(index=False)
+        }
+        self.besties_pairs: list[tuple[int, int]] = []
+        if relationships is not None and not relationships.empty:
+            besties = relationships[relationships["relationship"] == "besties"]
+            for row in besties.itertuples(index=False):
+                self.besties_pairs.append(
+                    (
+                        camper_id_by_key[(str(row.cabin_1), str(row.camper_1))],
+                        camper_id_by_key[(str(row.cabin_2), str(row.camper_2))],
+                    )
+                )
 
     def build(self, config: OptimizationConfig) -> pulp.LpProblem:
         """Build an unsolved LpProblem from domain data and optimization config.
@@ -100,6 +122,7 @@ class SchedulingProblem:
         self._add_preference_constraints(problem, camper_assignments)
         self._add_top2_guarantee_constraints(problem, camper_assignments)
         self._add_cabin_max_constraints(problem, camper_assignments)
+        self._add_besties_constraints(problem, camper_assignments)
         self._add_fleet_assignment_constraints(problem, fleet_assignment)
         self._add_fleet_balance_constraints(problem, fleet_assignment)
         self._add_gender_balance_constraints(problem, fleet_assignment)
@@ -215,6 +238,20 @@ class SchedulingProblem:
                     pulp.lpSum([camper_assignments[c][s] for c in self.campers_by_cabin[cabin]])
                     <= self._CABIN_MAX_PER_SEATRADE,
                     f"{cabin}_max_{self._CABIN_MAX_PER_SEATRADE}_campers_to_{s}",
+                )
+
+    def _add_besties_constraints(self, problem: pulp.LpProblem, camper_assignments: VarDict) -> None:
+        """Besties pairs get identical schedules.
+
+        Equating the camper's assignment for every block_seatrade forces the same
+        seatrade in the same block for both blocks; the linking constraints then pull
+        both campers' cabins into the same fleet. No auxiliary variables needed.
+        """
+        for c1, c2 in self.besties_pairs:
+            for s in self.seatrades_full:
+                problem += (
+                    camper_assignments[c1][s] == camper_assignments[c2][s],
+                    f"besties_{c1}_{c2}_{s}",
                 )
 
     def _add_fleet_assignment_constraints(self, problem: pulp.LpProblem, fleet_assignment: VarDict) -> None:

--- a/seatrades/simulation.py
+++ b/seatrades/simulation.py
@@ -142,7 +142,7 @@ class Camper(NamedTuple):
 
     cabin: str
     name: str
-    prefs: set
+    prefs: set[str]
 
     @property
     def key(self) -> tuple[str, str]:
@@ -171,7 +171,7 @@ def simulate_camper_relationships(
     used: set[tuple[str, str]] = set()
 
     def reserve_pair(
-        predicate: Callable[["Camper", "Camper"], bool],
+        predicate: Callable[[Camper, Camper], bool],
     ) -> Optional[tuple[tuple[str, str], tuple[str, str]]]:
         """Return the first unused pair matching predicate and mark both campers used.
 

--- a/seatrades/simulation.py
+++ b/seatrades/simulation.py
@@ -11,7 +11,19 @@ import pandas as pd
 from faker import Faker
 
 from seatrades import preferences
-from seatrades.config import NUM_PREFERENCES, PREF_COLS, CamperSimulationConfig, SeatradeSimulationConfig
+from seatrades.config import (
+    NUM_PREFERENCES,
+    PREF_COLS,
+    CamperRelationships,
+    CamperSimulationConfig,
+    SeatradeSimulationConfig,
+)
+
+# A besties pair needs two identical sessions, so its members must share >= 2
+# preferred seatrades for the identical-schedule constraint to stay feasible.
+_BESTIES_MIN_SHARED_SEATRADES = 2
+
+_RELATIONSHIP_COLUMNS = ["cabin_1", "camper_1", "cabin_2", "camper_2", "relationship"]
 
 # Real cabin names from Keats Camp
 GIRL_CABIN_EXAMPLES = [
@@ -127,3 +139,40 @@ def simulate_camper_preferences(
 
     result = pd.DataFrame(rows)
     return preferences.CamperPreferences.validate(result)  # type: ignore[return-value]
+
+
+def simulate_camper_relationships(
+    identity_df: pd.DataFrame,
+    preferences_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Generate one mock besties pair, guaranteed solver-feasible.
+
+    Picks the first same-cabin pair of campers sharing at least two preferred
+    seatrades. A same-cabin pair avoids fleet-balance conflicts at any cabin count,
+    and the shared preferences make an identical schedule achievable — so the seeded
+    besties relationship always solves. Returns an empty (but schema-valid)
+    CamperRelationships frame if no such pair exists.
+    """
+    merged = identity_df.merge(preferences_df, on="camper")
+    for cabin, group in merged.groupby("cabin"):
+        members = list(group.itertuples(index=False))
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                a, b = members[i], members[j]
+                shared = {getattr(a, col) for col in PREF_COLS} & {getattr(b, col) for col in PREF_COLS}
+                if len(shared) >= _BESTIES_MIN_SHARED_SEATRADES:
+                    row = pd.DataFrame(
+                        [
+                            {
+                                "cabin_1": cabin,
+                                "camper_1": a.camper,
+                                "cabin_2": cabin,
+                                "camper_2": b.camper,
+                                "relationship": "besties",
+                            }
+                        ]
+                    )
+                    return CamperRelationships.validate(row)  # type: ignore[return-value]
+
+    empty = pd.DataFrame({col: pd.Series(dtype="object") for col in _RELATIONSHIP_COLUMNS})
+    return CamperRelationships.validate(empty)  # type: ignore[return-value]

--- a/seatrades/simulation.py
+++ b/seatrades/simulation.py
@@ -5,7 +5,7 @@ and return validated pandas DataFrames.
 """
 
 import random
-from typing import Optional
+from typing import Callable, NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -137,6 +137,18 @@ def simulate_camper_preferences(
     return preferences.CamperPreferences.validate(result)  # type: ignore[return-value]
 
 
+class Camper(NamedTuple):
+    """A camper's identity and preferred seatrades, for pair selection."""
+
+    cabin: str
+    name: str
+    prefs: set
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.cabin, self.name)
+
+
 def simulate_camper_relationships(
     identity_df: pd.DataFrame,
     preferences_df: pd.DataFrame,
@@ -153,32 +165,40 @@ def simulate_camper_relationships(
     """
     merged = identity_df.merge(preferences_df, on="camper")
     campers = [
-        (str(row.cabin), str(row.camper), {getattr(row, col) for col in PREF_COLS})
+        Camper(str(row.cabin), str(row.camper), {getattr(row, col) for col in PREF_COLS})
         for row in merged.itertuples(index=False)
     ]
     used: set[tuple[str, str]] = set()
 
-    def find_pair(predicate) -> Optional[tuple[tuple[str, str], tuple[str, str]]]:
+    def reserve_pair(
+        predicate: Callable[["Camper", "Camper"], bool],
+    ) -> Optional[tuple[tuple[str, str], tuple[str, str]]]:
+        """Return the first unused pair matching predicate and mark both campers used.
+
+        Mutates ``used`` so later calls can't reuse a camper — distinct campers per
+        pair preclude contradictory friend/frenemy chains.
+        """
         for i in range(len(campers)):
             for j in range(i + 1, len(campers)):
                 a, b = campers[i], campers[j]
-                key_a, key_b = (a[0], a[1]), (b[0], b[1])
-                if key_a in used or key_b in used or not predicate(a, b):
+                if a.key in used or b.key in used or not predicate(a, b):
                     continue
-                used.update({key_a, key_b})
-                return key_a, key_b
+                used.update({a.key, b.key})
+                return a.key, b.key
         return None
 
-    def same_cabin(a, b) -> bool:
-        return a[0] == b[0]
+    def same_cabin(a: Camper, b: Camper) -> bool:
+        return a.cabin == b.cabin
 
-    def shared(a, b) -> int:
-        return len(a[2] & b[2])
+    def shared(a: Camper, b: Camper) -> int:
+        return len(a.prefs & b.prefs)
 
+    # Order is load-bearing: besties reserves first because its ≥2-shared pairs are
+    # scarcer than friends' ≥1-shared pairs; reordering could starve besties.
     selections = {
-        "besties": find_pair(lambda a, b: same_cabin(a, b) and shared(a, b) >= BESTIES_MIN_SHARED_SEATRADES),
-        "friends": find_pair(lambda a, b: same_cabin(a, b) and shared(a, b) >= FRIENDS_MIN_SHARED_SEATRADES),
-        "frenemies": find_pair(lambda a, b: not same_cabin(a, b)),
+        "besties": reserve_pair(lambda a, b: same_cabin(a, b) and shared(a, b) >= BESTIES_MIN_SHARED_SEATRADES),
+        "friends": reserve_pair(lambda a, b: same_cabin(a, b) and shared(a, b) >= FRIENDS_MIN_SHARED_SEATRADES),
+        "frenemies": reserve_pair(lambda a, b: not same_cabin(a, b)),
     }
 
     rows = [

--- a/seatrades/simulation.py
+++ b/seatrades/simulation.py
@@ -15,7 +15,6 @@ from seatrades.config import (
     BESTIES_MIN_SHARED_SEATRADES,
     NUM_PREFERENCES,
     PREF_COLS,
-    CamperRelationships,
     CamperSimulationConfig,
     SeatradeSimulationConfig,
 )
@@ -153,20 +152,20 @@ def simulate_camper_relationships(
         members = list(group.itertuples(index=False))
         for i in range(len(members)):
             for j in range(i + 1, len(members)):
-                a, b = members[i], members[j]
-                shared = {getattr(a, col) for col in PREF_COLS} & {getattr(b, col) for col in PREF_COLS}
+                camper_a, camper_b = members[i], members[j]
+                shared = {getattr(camper_a, col) for col in PREF_COLS} & {getattr(camper_b, col) for col in PREF_COLS}
                 if len(shared) >= BESTIES_MIN_SHARED_SEATRADES:
                     row = pd.DataFrame(
                         [
                             {
                                 "cabin_1": cabin,
-                                "camper_1": a.camper,
+                                "camper_1": camper_a.camper,
                                 "cabin_2": cabin,
-                                "camper_2": b.camper,
+                                "camper_2": camper_b.camper,
                                 "relationship": "besties",
                             }
                         ]
                     )
-                    return CamperRelationships.validate(row)  # type: ignore[return-value]
+                    return preferences.CamperRelationships.validate(row)  # type: ignore[return-value]
 
     return preferences.empty_relationships()

--- a/seatrades/simulation.py
+++ b/seatrades/simulation.py
@@ -5,6 +5,7 @@ and return validated pandas DataFrames.
 """
 
 import random
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -13,6 +14,7 @@ from faker import Faker
 from seatrades import preferences
 from seatrades.config import (
     BESTIES_MIN_SHARED_SEATRADES,
+    FRIENDS_MIN_SHARED_SEATRADES,
     NUM_PREFERENCES,
     PREF_COLS,
     CamperSimulationConfig,
@@ -139,33 +141,57 @@ def simulate_camper_relationships(
     identity_df: pd.DataFrame,
     preferences_df: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Generate one mock besties pair, guaranteed solver-feasible.
+    """Generate one mock pair of each relationship type, guaranteed solver-feasible.
 
-    Picks the first same-cabin pair of campers sharing at least two preferred
-    seatrades. A same-cabin pair avoids fleet-balance conflicts at any cabin count,
-    and the shared preferences make an identical schedule achievable — so the seeded
-    besties relationship always solves. Returns an empty (but schema-valid)
-    CamperRelationships frame if no such pair exists.
+    Each pair uses distinct campers, so the three constraints can never form a
+    contradictory friend/frenemy chain. The pairs are picked to stay individually
+    feasible: besties and friends from a same-cabin pair (always the same fleet, so a
+    shared schedule/session is achievable) sharing enough preferred seatrades, and
+    frenemies from a cross-cabin pair (separable into different fleets, so they need
+    never overlap). Any type with no qualifying pair is skipped; an empty (but
+    schema-valid) frame is returned when none can be seeded.
     """
     merged = identity_df.merge(preferences_df, on="camper")
-    for cabin, group in merged.groupby("cabin"):
-        members = list(group.itertuples(index=False))
-        for i in range(len(members)):
-            for j in range(i + 1, len(members)):
-                camper_a, camper_b = members[i], members[j]
-                shared = {getattr(camper_a, col) for col in PREF_COLS} & {getattr(camper_b, col) for col in PREF_COLS}
-                if len(shared) >= BESTIES_MIN_SHARED_SEATRADES:
-                    row = pd.DataFrame(
-                        [
-                            {
-                                "cabin_1": cabin,
-                                "camper_1": camper_a.camper,
-                                "cabin_2": cabin,
-                                "camper_2": camper_b.camper,
-                                "relationship": "besties",
-                            }
-                        ]
-                    )
-                    return preferences.CamperRelationships.validate(row)  # type: ignore[return-value]
+    campers = [
+        (str(row.cabin), str(row.camper), {getattr(row, col) for col in PREF_COLS})
+        for row in merged.itertuples(index=False)
+    ]
+    used: set[tuple[str, str]] = set()
 
-    return preferences.empty_relationships()
+    def find_pair(predicate) -> Optional[tuple[tuple[str, str], tuple[str, str]]]:
+        for i in range(len(campers)):
+            for j in range(i + 1, len(campers)):
+                a, b = campers[i], campers[j]
+                key_a, key_b = (a[0], a[1]), (b[0], b[1])
+                if key_a in used or key_b in used or not predicate(a, b):
+                    continue
+                used.update({key_a, key_b})
+                return key_a, key_b
+        return None
+
+    def same_cabin(a, b) -> bool:
+        return a[0] == b[0]
+
+    def shared(a, b) -> int:
+        return len(a[2] & b[2])
+
+    selections = {
+        "besties": find_pair(lambda a, b: same_cabin(a, b) and shared(a, b) >= BESTIES_MIN_SHARED_SEATRADES),
+        "friends": find_pair(lambda a, b: same_cabin(a, b) and shared(a, b) >= FRIENDS_MIN_SHARED_SEATRADES),
+        "frenemies": find_pair(lambda a, b: not same_cabin(a, b)),
+    }
+
+    rows = [
+        {
+            "cabin_1": pair[0][0],
+            "camper_1": pair[0][1],
+            "cabin_2": pair[1][0],
+            "camper_2": pair[1][1],
+            "relationship": relationship,
+        }
+        for relationship, pair in selections.items()
+        if pair is not None
+    ]
+    if not rows:
+        return preferences.empty_relationships()
+    return preferences.CamperRelationships.validate(pd.DataFrame(rows))  # type: ignore[return-value]

--- a/seatrades/simulation.py
+++ b/seatrades/simulation.py
@@ -12,18 +12,13 @@ from faker import Faker
 
 from seatrades import preferences
 from seatrades.config import (
+    BESTIES_MIN_SHARED_SEATRADES,
     NUM_PREFERENCES,
     PREF_COLS,
     CamperRelationships,
     CamperSimulationConfig,
     SeatradeSimulationConfig,
 )
-
-# A besties pair needs two identical sessions, so its members must share >= 2
-# preferred seatrades for the identical-schedule constraint to stay feasible.
-_BESTIES_MIN_SHARED_SEATRADES = 2
-
-_RELATIONSHIP_COLUMNS = ["cabin_1", "camper_1", "cabin_2", "camper_2", "relationship"]
 
 # Real cabin names from Keats Camp
 GIRL_CABIN_EXAMPLES = [
@@ -160,7 +155,7 @@ def simulate_camper_relationships(
             for j in range(i + 1, len(members)):
                 a, b = members[i], members[j]
                 shared = {getattr(a, col) for col in PREF_COLS} & {getattr(b, col) for col in PREF_COLS}
-                if len(shared) >= _BESTIES_MIN_SHARED_SEATRADES:
+                if len(shared) >= BESTIES_MIN_SHARED_SEATRADES:
                     row = pd.DataFrame(
                         [
                             {
@@ -174,5 +169,4 @@ def simulate_camper_relationships(
                     )
                     return CamperRelationships.validate(row)  # type: ignore[return-value]
 
-    empty = pd.DataFrame({col: pd.Series(dtype="object") for col in _RELATIONSHIP_COLUMNS})
-    return CamperRelationships.validate(empty)  # type: ignore[return-value]
+    return preferences.empty_relationships()

--- a/tests/test_app/test_friends_tab.py
+++ b/tests/test_app/test_friends_tab.py
@@ -1,0 +1,33 @@
+"""Friends tab tests — relationship seeding and rendering via Streamlit AppTest."""
+
+from pathlib import Path
+
+from streamlit.testing.v1 import AppTest
+
+APP_SCRIPT = str(Path(__file__).resolve().parents[2] / "app.py")
+
+
+class TestFriendsTab:
+    def test_app_seeds_a_besties_pair_for_the_default_roster(self):
+        at = AppTest.from_file(APP_SCRIPT, default_timeout=60)
+        at.run()
+
+        assert not at.exception
+        relationships = at.session_state["camper_relationships"]
+        assert (relationships["relationship"] == "besties").any()
+
+    def test_seeded_besties_pair_is_same_cabin(self):
+        at = AppTest.from_file(APP_SCRIPT, default_timeout=60)
+        at.run()
+
+        relationships = at.session_state["camper_relationships"]
+        besties = relationships[relationships["relationship"] == "besties"]
+        assert (besties["cabin_1"] == besties["cabin_2"]).all()
+
+    def test_friends_tab_renders_relationship_editor(self):
+        at = AppTest.from_file(APP_SCRIPT, default_timeout=60)
+        at.run()
+
+        assert not at.exception
+        # The editable relationships grid is present (data_editor renders no exception).
+        assert any("Friends" in m.value for m in at.subheader)

--- a/tests/test_seatrades/test_preferences.py
+++ b/tests/test_seatrades/test_preferences.py
@@ -5,9 +5,16 @@ from io import StringIO
 import pandas as pd
 import pytest
 
-from seatrades.config import CamperIdentity, CamperPreferences, SeatradesConfig
+from seatrades.config import (
+    BESTIES_MIN_SHARED_SEATRADES,
+    CamperIdentity,
+    CamperPreferences,
+    CamperRelationships,
+    SeatradesConfig,
+)
 from seatrades.preferences import (
     ValidationError,
+    empty_relationships,
     join_and_validate,
     read_csv_for_schema,
     validate_relationships,
@@ -654,6 +661,43 @@ class TestValidateRelationships:
             validate_relationships(relationships, joined, "Camper Relationships")
 
         assert any("relationship" in e for e in exc_info.value.errors)
+
+    def test_duplicate_pair_does_not_cascade_other_errors(self):
+        # Two identical infeasible besties rows: the first row reports "share fewer";
+        # the duplicate row reports only "duplicate", not a second "share fewer".
+        joined = _two_cabin_joined()
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Puffin", "Puffin"],
+                "camper_1": ["Alice", "Alice"],
+                "cabin_2": ["Tillikum", "Tillikum"],
+                "camper_2": ["Carlos", "Carlos"],
+                "relationship": ["besties", "besties"],
+            }
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        errors = exc_info.value.errors
+        assert sum("duplicate" in e.lower() for e in errors) == 1
+        assert sum("share fewer" in e for e in errors) == 1
+
+
+class TestEmptyRelationships:
+    """empty_relationships builds a schema-valid, zero-row CamperRelationships frame."""
+
+    def test_has_schema_columns_and_is_empty(self):
+        result = empty_relationships()
+
+        assert list(result.columns) == ["cabin_1", "camper_1", "cabin_2", "camper_2", "relationship"]
+        assert len(result) == 0
+        CamperRelationships.validate(result)
+
+
+def test_besties_min_shared_seatrades_is_single_source():
+    """The feasibility threshold has one home in config, imported everywhere else."""
+    assert BESTIES_MIN_SHARED_SEATRADES == 2
 
 
 class TestReadCsvForSchema:

--- a/tests/test_seatrades/test_preferences.py
+++ b/tests/test_seatrades/test_preferences.py
@@ -10,8 +10,40 @@ from seatrades.preferences import (
     ValidationError,
     join_and_validate,
     read_csv_for_schema,
+    validate_relationships,
     validate_schema,
 )
+
+
+def _two_cabin_joined() -> pd.DataFrame:
+    """Joined-campers df (post identity/preferences merge) for relationship tests.
+
+    Alice and Bob share Sailing+Climbing (≥2) so a besties pair between them is feasible.
+    Carlos shares only Archery with each, so a besties pair to Carlos is infeasible.
+    """
+    return pd.DataFrame(
+        {
+            "cabin": ["Puffin", "Puffin", "Tillikum"],
+            "camper": ["Alice", "Bob", "Carlos"],
+            "gender": ["female", "female", "male"],
+            "seatrade_1": ["Sailing", "Climbing", "Archery"],
+            "seatrade_2": ["Climbing", "Sailing", "Kayaking"],
+            "seatrade_3": ["Archery", "Archery", "Tubing"],
+            "seatrade_4": ["Crafts", "Swimming", "Wibit"],
+        }
+    )
+
+
+def _relationship_row(cabin_1, camper_1, cabin_2, camper_2, relationship) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "cabin_1": [cabin_1],
+            "camper_1": [camper_1],
+            "cabin_2": [cabin_2],
+            "camper_2": [camper_2],
+            "relationship": [relationship],
+        }
+    )
 
 
 class TestJoinAndValidateHappyPath:
@@ -42,8 +74,9 @@ class TestJoinAndValidateHappyPath:
             }
         )
 
-        joined_campers, seatrade_setup = join_and_validate(identity_df, preferences_df, seatrade_df)
+        joined_campers, seatrade_setup, relationships = join_and_validate(identity_df, preferences_df, seatrade_df)
 
+        assert relationships is None
         assert "cabin" in joined_campers.columns
         assert "camper" in joined_campers.columns
         assert "gender" in joined_campers.columns
@@ -75,7 +108,7 @@ class TestJoinAndValidateHappyPath:
             }
         )
 
-        _, seatrade_setup = join_and_validate(identity_df, preferences_df, seatrade_df)
+        _, seatrade_setup, _ = join_and_validate(identity_df, preferences_df, seatrade_df)
 
         assert len(seatrade_setup) == 4
         assert "seatrade" in seatrade_setup.columns
@@ -450,6 +483,177 @@ class TestValidateSchema:
         with pytest.raises(ValidationError) as exc_info:
             validate_schema(CamperIdentity, df, "Camper Identity")
         assert len(exc_info.value.errors) >= 2
+
+
+class TestJoinAndValidateRelationships:
+    """join_and_validate accepts optional relationships and returns them validated."""
+
+    def _consistent_inputs(self):
+        identity_df = pd.DataFrame(
+            {
+                "cabin": ["Puffin", "Puffin"],
+                "camper": ["Alice", "Bob"],
+                "gender": ["female", "female"],
+            }
+        )
+        preferences_df = pd.DataFrame(
+            {
+                "camper": ["Alice", "Bob"],
+                "seatrade_1": ["Sailing", "Climbing"],
+                "seatrade_2": ["Climbing", "Sailing"],
+                "seatrade_3": ["Archery", "Archery"],
+                "seatrade_4": ["Crafts", "Swimming"],
+            }
+        )
+        seatrade_df = pd.DataFrame(
+            {
+                "seatrade": ["Sailing", "Climbing", "Archery", "Crafts", "Swimming"],
+                "campers_min": [0, 0, 0, 0, 0],
+                "campers_max": [10, 10, 10, 10, 10],
+            }
+        )
+        return identity_df, preferences_df, seatrade_df
+
+    def test_empty_relationships_returns_none(self):
+        identity_df, preferences_df, seatrade_df = self._consistent_inputs()
+        empty = _relationship_row("Puffin", "Alice", "Puffin", "Bob", "besties").iloc[0:0]
+
+        _, _, relationships = join_and_validate(identity_df, preferences_df, seatrade_df, empty)
+
+        assert relationships is None
+
+    def test_valid_relationships_returned(self):
+        identity_df, preferences_df, seatrade_df = self._consistent_inputs()
+        rel = _relationship_row("Puffin", "Alice", "Puffin", "Bob", "besties")
+
+        _, _, relationships = join_and_validate(identity_df, preferences_df, seatrade_df, rel)
+
+        assert relationships is not None
+        assert len(relationships) == 1
+
+    def test_infeasible_besties_relationship_raises(self):
+        identity_df, preferences_df, seatrade_df = self._consistent_inputs()
+        # Alice & Bob share Sailing+Climbing+Archery, so make Bob's prefs disjoint enough:
+        preferences_df.loc[
+            preferences_df["camper"] == "Bob", ["seatrade_1", "seatrade_2", "seatrade_3", "seatrade_4"]
+        ] = [
+            "Climbing",
+            "Tubing",
+            "Kayaking",
+            "Wibit",
+        ]
+        seatrade_df = pd.DataFrame(
+            {
+                "seatrade": ["Sailing", "Climbing", "Archery", "Crafts", "Tubing", "Kayaking", "Wibit"],
+                "campers_min": [0] * 7,
+                "campers_max": [10] * 7,
+            }
+        )
+        rel = _relationship_row("Puffin", "Alice", "Puffin", "Bob", "besties")
+
+        with pytest.raises(ValidationError) as exc_info:
+            join_and_validate(identity_df, preferences_df, seatrade_df, rel)
+
+        assert any("share fewer" in e for e in exc_info.value.errors)
+
+
+class TestValidateRelationships:
+    """validate_relationships checks schema, self-pairs, duplicates, cross-refs, feasibility."""
+
+    def test_valid_besties_pair_passes(self):
+        joined = _two_cabin_joined()
+        relationships = _relationship_row("Puffin", "Alice", "Puffin", "Bob", "besties")
+
+        result = validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 1
+
+    def test_self_pair_rejected_naming_camper(self):
+        joined = _two_cabin_joined()
+        relationships = _relationship_row("Puffin", "Alice", "Puffin", "Alice", "besties")
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert any("Alice" in e and "Puffin" in e for e in exc_info.value.errors)
+        assert any("itself" in e.lower() or "self" in e.lower() for e in exc_info.value.errors)
+
+    def test_duplicate_pair_rejected_regardless_of_order(self):
+        joined = _two_cabin_joined()
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Puffin", "Puffin"],
+                "camper_1": ["Alice", "Bob"],
+                "cabin_2": ["Puffin", "Puffin"],
+                "camper_2": ["Bob", "Alice"],
+                "relationship": ["besties", "besties"],
+            }
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert any("duplicate" in e.lower() for e in exc_info.value.errors)
+        assert any("Alice" in e and "Bob" in e for e in exc_info.value.errors)
+
+    def test_unknown_camper_rejected_naming_offender(self):
+        joined = _two_cabin_joined()
+        relationships = _relationship_row("Puffin", "Alice", "Puffin", "Zelda", "besties")
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert any("Zelda" in e and "Puffin" in e for e in exc_info.value.errors)
+        assert any("not" in e.lower() and "camper" in e.lower() for e in exc_info.value.errors)
+
+    def test_unknown_camper_skips_feasibility_check(self):
+        """An unknown camper is reported once; the besties feasibility check is not run on it."""
+        joined = _two_cabin_joined()
+        relationships = _relationship_row("Nowhere", "Ghost", "Puffin", "Alice", "besties")
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert any("Ghost" in e for e in exc_info.value.errors)
+        assert not any("share fewer" in e for e in exc_info.value.errors)
+
+    def test_besties_with_too_few_shared_preferences_rejected(self):
+        # Alice and Carlos share only Archery (1 < 2) — no feasible identical schedule.
+        joined = _two_cabin_joined()
+        relationships = _relationship_row("Puffin", "Alice", "Tillikum", "Carlos", "besties")
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert any("share fewer" in e for e in exc_info.value.errors)
+        assert any("Alice" in e and "Carlos" in e for e in exc_info.value.errors)
+
+    def test_friends_and_frenemies_pass_regardless_of_preference_overlap(self):
+        # Alice & Carlos share only 1 seatrade — fine for friends/frenemies (unenforced this slice).
+        joined = _two_cabin_joined()
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Puffin", "Puffin"],
+                "camper_1": ["Alice", "Bob"],
+                "cabin_2": ["Tillikum", "Tillikum"],
+                "camper_2": ["Carlos", "Carlos"],
+                "relationship": ["friends", "frenemies"],
+            }
+        )
+
+        result = validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert len(result) == 2
+
+    def test_invalid_relationship_value_rejected(self):
+        joined = _two_cabin_joined()
+        relationships = _relationship_row("Puffin", "Alice", "Puffin", "Bob", "rivals")
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert any("relationship" in e for e in exc_info.value.errors)
 
 
 class TestReadCsvForSchema:

--- a/tests/test_seatrades/test_preferences.py
+++ b/tests/test_seatrades/test_preferences.py
@@ -7,6 +7,7 @@ import pytest
 
 from seatrades.config import (
     BESTIES_MIN_SHARED_SEATRADES,
+    FRIENDS_MIN_SHARED_SEATRADES,
     CamperIdentity,
     CamperPreferences,
     CamperRelationships,
@@ -674,6 +675,9 @@ class TestValidateRelationships:
 
         assert any("Alice" in e and "Carlos" in e for e in exc_info.value.errors)
         assert any("no shared session" in e for e in exc_info.value.errors)
+        # Message references the threshold constant, like the besties branch, so it
+        # stays correct if FRIENDS_MIN_SHARED_SEATRADES is ever raised.
+        assert any(f"fewer than {FRIENDS_MIN_SHARED_SEATRADES}" in e for e in exc_info.value.errors)
 
     def test_frenemies_with_no_shared_preference_passes(self):
         # Frenemies has no preference precondition — disjoint prefs are fine.

--- a/tests/test_seatrades/test_preferences.py
+++ b/tests/test_seatrades/test_preferences.py
@@ -636,8 +636,9 @@ class TestValidateRelationships:
         assert any("share fewer" in e for e in exc_info.value.errors)
         assert any("Alice" in e and "Carlos" in e for e in exc_info.value.errors)
 
-    def test_friends_and_frenemies_pass_regardless_of_preference_overlap(self):
-        # Alice & Carlos share only 1 seatrade — fine for friends/frenemies (unenforced this slice).
+    def test_friends_and_frenemies_pass_with_one_shared_preference(self):
+        # Alice & Carlos share 1 seatrade (Archery): enough for friends (≥1), and
+        # frenemies has no preference precondition.
         joined = _two_cabin_joined()
         relationships = pd.DataFrame(
             {
@@ -652,6 +653,46 @@ class TestValidateRelationships:
         result = validate_relationships(relationships, joined, "Camper Relationships")
 
         assert len(result) == 2
+
+    def test_friends_with_no_shared_preference_rejected(self):
+        # Disjoint preferences — the pair can never co-occupy a session.
+        joined = pd.DataFrame(
+            {
+                "cabin": ["Puffin", "Tillikum"],
+                "camper": ["Alice", "Carlos"],
+                "gender": ["female", "male"],
+                "seatrade_1": ["Sailing", "Archery"],
+                "seatrade_2": ["Climbing", "Kayaking"],
+                "seatrade_3": ["Crafts", "Tubing"],
+                "seatrade_4": ["Swimming", "Wibit"],
+            }
+        )
+        relationships = _relationship_row("Puffin", "Alice", "Tillikum", "Carlos", "friends")
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert any("Alice" in e and "Carlos" in e for e in exc_info.value.errors)
+        assert any("no shared session" in e for e in exc_info.value.errors)
+
+    def test_frenemies_with_no_shared_preference_passes(self):
+        # Frenemies has no preference precondition — disjoint prefs are fine.
+        joined = pd.DataFrame(
+            {
+                "cabin": ["Puffin", "Tillikum"],
+                "camper": ["Alice", "Carlos"],
+                "gender": ["female", "male"],
+                "seatrade_1": ["Sailing", "Archery"],
+                "seatrade_2": ["Climbing", "Kayaking"],
+                "seatrade_3": ["Crafts", "Tubing"],
+                "seatrade_4": ["Swimming", "Wibit"],
+            }
+        )
+        relationships = _relationship_row("Puffin", "Alice", "Tillikum", "Carlos", "frenemies")
+
+        result = validate_relationships(relationships, joined, "Camper Relationships")
+
+        assert len(result) == 1
 
     def test_invalid_relationship_value_rejected(self):
         joined = _two_cabin_joined()

--- a/tests/test_seatrades/test_problem.py
+++ b/tests/test_seatrades/test_problem.py
@@ -148,6 +148,43 @@ class TestSchedulingProblemRebuild:
         assert problem_a is not problem_b
 
 
+class TestSchedulingProblemBesties:
+    """Relationships map (cabin, camper) pairs to internal camper ids for the solver."""
+
+    def test_besties_pair_mapped_to_camper_ids(self, joined_campers_df, seatrade_setup_df):
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1"],
+                "camper_1": ["Alice"],
+                "cabin_2": ["Cabin2"],
+                "camper_2": ["Carol"],
+                "relationship": ["besties"],
+            }
+        )
+        problem = SchedulingProblem(joined_campers_df, seatrade_setup_df, relationships=relationships)
+
+        # Alice is row 0, Carol is row 2.
+        assert problem.besties_pairs == [(0, 2)]
+
+    def test_no_relationships_means_no_besties_pairs(self, scheduling_problem):
+        assert scheduling_problem.besties_pairs == []
+
+    def test_only_besties_rows_become_pairs(self, joined_campers_df, seatrade_setup_df):
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1", "Cabin1"],
+                "camper_1": ["Alice", "Bob"],
+                "cabin_2": ["Cabin2", "Cabin2"],
+                "camper_2": ["Carol", "Dave"],
+                "relationship": ["besties", "friends"],
+            }
+        )
+        problem = SchedulingProblem(joined_campers_df, seatrade_setup_df, relationships=relationships)
+
+        # Only the besties row (Alice id 0, Carol id 2) is enforced this slice.
+        assert problem.besties_pairs == [(0, 2)]
+
+
 class TestSchedulingProblemConstraintGroups:
     """Each constraint-group method adds only its constraints to a fresh problem."""
 
@@ -332,6 +369,35 @@ class TestSchedulingProblemConstraintGroups:
         config = OptimizationConfig(max_seatrades_per_fleet=None)
 
         sp._add_max_seatrades_per_fleet_constraints(problem, vars_["seatrade_assignment"], config)
+
+        assert len(problem.constraints) == 0
+
+    def test_add_besties_constraints(self, joined_campers_df, seatrade_setup_df):
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1"],
+                "camper_1": ["Alice"],
+                "cabin_2": ["Cabin2"],
+                "camper_2": ["Carol"],
+                "relationship": ["besties"],
+            }
+        )
+        sp = SchedulingProblem(joined_campers_df, seatrade_setup_df, relationships=relationships)
+        problem = pulp.LpProblem("test_besties")
+        vars_ = self._make_vars(sp)
+
+        sp._add_besties_constraints(problem, vars_["camper_assignments"])
+
+        # One equality per block_seatrade for the single besties pair.
+        assert len(problem.constraints) == len(sp.seatrades_full)
+        assert any(name.startswith("besties_") for name in problem.constraints)
+
+    def test_add_besties_constraints_noop_without_relationships(self, scheduling_problem):
+        sp = scheduling_problem
+        problem = pulp.LpProblem("test_besties_none")
+        vars_ = self._make_vars(sp)
+
+        sp._add_besties_constraints(problem, vars_["camper_assignments"])
 
         assert len(problem.constraints) == 0
 

--- a/tests/test_seatrades/test_problem.py
+++ b/tests/test_seatrades/test_problem.py
@@ -169,20 +169,26 @@ class TestSchedulingProblemBesties:
     def test_no_relationships_means_no_besties_pairs(self, scheduling_problem):
         assert scheduling_problem.besties_pairs == []
 
-    def test_only_besties_rows_become_pairs(self, joined_campers_df, seatrade_setup_df):
+    def test_relationship_rows_split_by_type(self, joined_campers_df, seatrade_setup_df):
         relationships = pd.DataFrame(
             {
-                "cabin_1": ["Cabin1", "Cabin1"],
-                "camper_1": ["Alice", "Bob"],
-                "cabin_2": ["Cabin2", "Cabin2"],
-                "camper_2": ["Carol", "Dave"],
-                "relationship": ["besties", "friends"],
+                "cabin_1": ["Cabin1", "Cabin1", "Cabin1"],
+                "camper_1": ["Alice", "Bob", "Alice"],
+                "cabin_2": ["Cabin2", "Cabin2", "Cabin2"],
+                "camper_2": ["Carol", "Dave", "Dave"],
+                "relationship": ["besties", "friends", "frenemies"],
             }
         )
         problem = SchedulingProblem(joined_campers_df, seatrade_setup_df, relationships=relationships)
 
-        # Only the besties row (Alice id 0, Carol id 2) is enforced this slice.
+        # camper_ids: Alice=0, Bob=1, Carol=2, Dave=3. Each list holds only its type.
         assert problem.besties_pairs == [(0, 2)]
+        assert problem.friends_pairs == [(1, 3)]
+        assert problem.frenemies_pairs == [(0, 3)]
+
+    def test_no_relationships_means_no_friends_or_frenemies_pairs(self, scheduling_problem):
+        assert scheduling_problem.friends_pairs == []
+        assert scheduling_problem.frenemies_pairs == []
 
 
 class TestSchedulingProblemConstraintGroups:
@@ -398,6 +404,48 @@ class TestSchedulingProblemConstraintGroups:
         vars_ = self._make_vars(sp)
 
         sp._add_besties_constraints(problem, vars_["camper_assignments"])
+
+        assert len(problem.constraints) == 0
+
+    def _relationships(self, relationship):
+        return pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1"],
+                "camper_1": ["Alice"],
+                "cabin_2": ["Cabin2"],
+                "camper_2": ["Carol"],
+                "relationship": [relationship],
+            }
+        )
+
+    def test_add_friends_constraints(self, joined_campers_df, seatrade_setup_df):
+        sp = SchedulingProblem(joined_campers_df, seatrade_setup_df, relationships=self._relationships("friends"))
+        problem = pulp.LpProblem("test_friends")
+        vars_ = self._make_vars(sp)
+
+        sp._add_friends_constraints(problem, vars_["camper_assignments"])
+
+        # Three AND-linearization constraints per session, plus one >=1 overlap sum.
+        assert any(name.startswith("friends_") for name in problem.constraints)
+        assert len(problem.constraints) == 3 * len(sp.seatrades_full) + 1
+
+    def test_add_frenemies_constraints(self, joined_campers_df, seatrade_setup_df):
+        sp = SchedulingProblem(joined_campers_df, seatrade_setup_df, relationships=self._relationships("frenemies"))
+        problem = pulp.LpProblem("test_frenemies")
+        vars_ = self._make_vars(sp)
+
+        sp._add_frenemies_constraints(problem, vars_["camper_assignments"])
+
+        assert any(name.startswith("frenemies_") for name in problem.constraints)
+        assert len(problem.constraints) == 3 * len(sp.seatrades_full) + 1
+
+    def test_add_friends_constraints_noop_without_relationships(self, scheduling_problem):
+        sp = scheduling_problem
+        problem = pulp.LpProblem("test_friends_none")
+        vars_ = self._make_vars(sp)
+
+        sp._add_friends_constraints(problem, vars_["camper_assignments"])
+        sp._add_frenemies_constraints(problem, vars_["camper_assignments"])
 
         assert len(problem.constraints) == 0
 

--- a/tests/test_seatrades/test_simulation.py
+++ b/tests/test_seatrades/test_simulation.py
@@ -162,6 +162,51 @@ class TestSimulateCamperRelationships:
             }
         )
 
+    def _roster_identity(self):
+        return pd.DataFrame(
+            {
+                "cabin": ["Puffin", "Puffin", "Tillikum", "Tillikum", "Orca", "Narwhal"],
+                "camper": ["Alice", "Bob", "Carlos", "Dana", "Eve", "Frank"],
+                "gender": ["female", "female", "male", "male", "female", "male"],
+            }
+        )
+
+    def _roster_preferences(self):
+        # Alice&Bob (same cabin) share ≥2 → besties. Other pairs share ≥1 → friends/frenemies.
+        return pd.DataFrame(
+            {
+                "camper": ["Alice", "Bob", "Carlos", "Dana", "Eve", "Frank"],
+                "seatrade_1": ["Sailing", "Climbing", "Archery", "Sailing", "Climbing", "Kayaking"],
+                "seatrade_2": ["Climbing", "Sailing", "Sailing", "Archery", "Kayaking", "Tubing"],
+                "seatrade_3": ["Archery", "Archery", "Kayaking", "Crafts", "Tubing", "Wibit"],
+                "seatrade_4": ["Crafts", "Swimming", "Tubing", "Wibit", "Wibit", "Swimming"],
+            }
+        )
+
+    def test_seeds_friends_and_frenemies_rows(self):
+        result = simulate_camper_relationships(self._roster_identity(), self._roster_preferences())
+
+        seeded = set(result["relationship"])
+        assert "friends" in seeded
+        assert "frenemies" in seeded
+
+    def test_seeded_pairs_use_distinct_campers(self):
+        result = simulate_camper_relationships(self._roster_identity(), self._roster_preferences())
+
+        campers = [(r.cabin_1, r.camper_1) for r in result.itertuples()] + [
+            (r.cabin_2, r.camper_2) for r in result.itertuples()
+        ]
+        # Disjoint camper sets across pairs preclude contradictory friend/frenemy chains.
+        assert len(campers) == len(set(campers))
+
+    def test_seeded_roster_passes_validation(self):
+        identity, prefs = self._roster_identity(), self._roster_preferences()
+        joined = identity.merge(prefs, on="camper")
+
+        result = simulate_camper_relationships(identity, prefs)
+
+        validate_relationships(result, joined, "Camper Relationships")
+
     def test_returns_single_same_cabin_besties_row(self):
         result = simulate_camper_relationships(self._identity(), self._preferences())
 

--- a/tests/test_seatrades/test_simulation.py
+++ b/tests/test_seatrades/test_simulation.py
@@ -2,7 +2,8 @@
 
 import pandas as pd
 
-from seatrades.config import CamperSimulationConfig, SeatradeSimulationConfig
+from seatrades.config import CamperRelationships, CamperSimulationConfig, SeatradeSimulationConfig
+from seatrades.preferences import validate_relationships
 from seatrades.simulation import (
     ALL_CABIN_DICT,
     BOY_CABIN_EXAMPLES,
@@ -10,6 +11,7 @@ from seatrades.simulation import (
     SEATRADE_EXAMPLES,
     simulate_camper_identity,
     simulate_camper_preferences,
+    simulate_camper_relationships,
     simulate_seatrade_preferences,
 )
 
@@ -134,3 +136,64 @@ class TestSimulateCamperPreferences:
         from seatrades.config import CamperPreferences
 
         CamperPreferences.validate(result)
+
+
+class TestSimulateCamperRelationships:
+    """simulate_camper_relationships produces a feasible mock besties pair."""
+
+    def _identity(self):
+        return pd.DataFrame(
+            {
+                "cabin": ["Puffin", "Puffin", "Tillikum"],
+                "camper": ["Alice", "Bob", "Carlos"],
+                "gender": ["female", "female", "male"],
+            }
+        )
+
+    def _preferences(self):
+        # Alice and Bob (same cabin) share Sailing + Climbing (≥2). Carlos shares <2 with each.
+        return pd.DataFrame(
+            {
+                "camper": ["Alice", "Bob", "Carlos"],
+                "seatrade_1": ["Sailing", "Climbing", "Archery"],
+                "seatrade_2": ["Climbing", "Sailing", "Kayaking"],
+                "seatrade_3": ["Archery", "Archery", "Tubing"],
+                "seatrade_4": ["Crafts", "Swimming", "Wibit"],
+            }
+        )
+
+    def test_returns_single_same_cabin_besties_row(self):
+        result = simulate_camper_relationships(self._identity(), self._preferences())
+
+        assert len(result) == 1
+        row = result.iloc[0]
+        assert row["relationship"] == "besties"
+        assert row["cabin_1"] == row["cabin_2"]
+
+    def test_generated_pair_passes_validation(self):
+        identity, prefs = self._identity(), self._preferences()
+        joined = identity.merge(prefs, on="camper")
+
+        result = simulate_camper_relationships(identity, prefs)
+
+        # The seeded pair must survive validate_relationships (known + feasible).
+        validate_relationships(result, joined, "Camper Relationships")
+
+    def test_empty_when_no_feasible_pair(self):
+        identity = pd.DataFrame(
+            {"cabin": ["Puffin", "Puffin"], "camper": ["Solo", "Lone"], "gender": ["female", "female"]}
+        )
+        prefs = pd.DataFrame(
+            {
+                "camper": ["Solo", "Lone"],
+                "seatrade_1": ["Archery", "Sailing"],
+                "seatrade_2": ["Climbing", "Crafts"],
+                "seatrade_3": ["Kayaking", "Tubing"],
+                "seatrade_4": ["Wibit", "Swimming"],
+            }
+        )
+
+        result = simulate_camper_relationships(identity, prefs)
+
+        assert len(result) == 0
+        CamperRelationships.validate(result)

--- a/tests/test_seatrades/test_solver.py
+++ b/tests/test_seatrades/test_solver.py
@@ -13,6 +13,7 @@ from seatrades.results import (
     wrangle_assignments_to_longform,
     wrangle_assignments_to_wideform,
 )
+from seatrades.simulation import simulate_camper_relationships
 from seatrades.solver import run
 
 
@@ -289,6 +290,49 @@ class TestFriendsFrenemiesConstraints:
         solution = run(problem, self._config)
 
         assert solution.status.state == SolverState.INFEASIBLE
+
+
+class TestSeededRosterSolves:
+    """The mock generator's seeded relationships must solve end-to-end (CONTEXT.md:86)."""
+
+    _identity = pd.DataFrame(
+        {
+            "cabin": ["Puffin", "Puffin", "Tillikum", "Tillikum", "Orca", "Narwhal"],
+            "camper": ["Alice", "Bob", "Carlos", "Dana", "Eve", "Frank"],
+            "gender": ["female", "female", "male", "male", "female", "male"],
+        }
+    )
+    # Alice&Bob (same cabin) share ≥2 → besties; Carlos&Dana (same cabin) share ≥1 →
+    # friends; the remaining cross-cabin pair → frenemies.
+    _preferences = pd.DataFrame(
+        {
+            "camper": ["Alice", "Bob", "Carlos", "Dana", "Eve", "Frank"],
+            "seatrade_1": ["Sailing", "Climbing", "Archery", "Sailing", "Climbing", "Kayaking"],
+            "seatrade_2": ["Climbing", "Sailing", "Sailing", "Archery", "Kayaking", "Tubing"],
+            "seatrade_3": ["Archery", "Archery", "Kayaking", "Crafts", "Tubing", "Wibit"],
+            "seatrade_4": ["Crafts", "Swimming", "Tubing", "Wibit", "Wibit", "Swimming"],
+        }
+    )
+    _setup = pd.DataFrame(
+        {
+            "seatrade": ["Sailing", "Climbing", "Archery", "Crafts", "Kayaking", "Tubing", "Wibit", "Swimming"],
+            "campers_min": [0] * 8,
+            "campers_max": [10] * 8,
+        }
+    )
+    _config = OptimizationConfig(solver=pulp.apis.PULP_CBC_CMD(msg=0))
+
+    def test_all_three_seeded_relationships_solve(self):
+        relationships = simulate_camper_relationships(self._identity, self._preferences)
+        # Guard the premise: the generator must actually seed all three types.
+        assert set(relationships["relationship"]) == {"besties", "friends", "frenemies"}
+
+        joined = self._identity.merge(self._preferences, on="camper")
+        problem = SchedulingProblem(joined, self._setup, relationships=relationships)
+
+        solution = run(problem, self._config)
+
+        assert solution.status.state == SolverState.OPTIMAL
 
 
 class TestMangle:

--- a/tests/test_seatrades/test_solver.py
+++ b/tests/test_seatrades/test_solver.py
@@ -147,6 +147,63 @@ class TestSolverRun:
         assert set(alex_wide["cabin"]) == {"Cabin1", "Cabin2"}
 
 
+class TestBestiesConstraint:
+    """A besties pair must receive an identical schedule end-to-end."""
+
+    _joined = pd.DataFrame(
+        {
+            "cabin": ["Cabin1", "Cabin1", "Cabin2", "Cabin2"],
+            "camper": ["Alice", "Bob", "Carol", "Dave"],
+            "gender": ["F", "M", "F", "M"],
+            "seatrade_1": ["Archery", "Climbing", "Sailing", "Archery"],
+            "seatrade_2": ["Sailing", "Archery", "Archery", "Climbing"],
+            "seatrade_3": ["Climbing", "Sailing", "Climbing", "Sailing"],
+            "seatrade_4": ["Kayaking", "Kayaking", "Kayaking", "Kayaking"],
+        }
+    )
+    _setup = pd.DataFrame(
+        {
+            "seatrade": ["Archery", "Sailing", "Climbing", "Kayaking"],
+            "campers_min": [0, 0, 0, 0],
+            "campers_max": [10, 10, 10, 10],
+        }
+    )
+
+    def test_besties_pair_gets_identical_schedule(self):
+        # Alice and Bob are both in Cabin1 and share Archery/Sailing/Climbing/Kayaking.
+        # A same-cabin pair stays feasible under fleet-balance regardless of cabin count.
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1"],
+                "camper_1": ["Alice"],
+                "cabin_2": ["Cabin1"],
+                "camper_2": ["Bob"],
+                "relationship": ["besties"],
+            }
+        )
+        problem = SchedulingProblem(self._joined, self._setup, relationships=relationships)
+        config = OptimizationConfig(solver=pulp.apis.PULP_CBC_CMD(msg=0))
+
+        solution = run(problem, config)
+
+        assert solution.status.state == SolverState.OPTIMAL
+        # camper_ids: Alice=0, Bob=1. Identical assignment row across all seatrades.
+        alice = solution.assignments.loc[0]
+        bob = solution.assignments.loc[1]
+        assert (alice == bob).all(), f"besties schedules differ:\n{alice}\n{bob}"
+
+    def test_without_relationships_pair_need_not_match(self):
+        """Sanity: the identical-schedule outcome comes from the constraint, not the data."""
+        problem = SchedulingProblem(self._joined, self._setup)
+        config = OptimizationConfig(solver=pulp.apis.PULP_CBC_CMD(msg=0))
+
+        solution = run(problem, config)
+
+        assert solution.status.state == SolverState.OPTIMAL
+        besties_names = [name for name in problem.build(config).constraints if name.startswith("besties_")]
+        assert besties_names == []
+
+
 class TestMangle:
     """Name mangling must match PuLP's internal variable naming."""
 

--- a/tests/test_seatrades/test_solver.py
+++ b/tests/test_seatrades/test_solver.py
@@ -5,6 +5,7 @@ import pulp
 import pytest
 
 from seatrades.config import OptimizationConfig
+from seatrades.preferences import validate_relationships
 from seatrades.problem import SchedulingProblem
 from seatrades.results import (
     AssignmentSolution,
@@ -202,6 +203,92 @@ class TestBestiesConstraint:
         assert solution.status.state == SolverState.OPTIMAL
         besties_names = [name for name in problem.build(config).constraints if name.startswith("besties_")]
         assert besties_names == []
+
+
+class TestFriendsFrenemiesConstraints:
+    """Friends pairs share a session end-to-end; frenemies pairs share none."""
+
+    _joined = pd.DataFrame(
+        {
+            "cabin": ["Cabin1", "Cabin1", "Cabin2", "Cabin2"],
+            "camper": ["Alice", "Bob", "Carol", "Dave"],
+            "gender": ["F", "M", "F", "M"],
+            "seatrade_1": ["Archery", "Archery", "Sailing", "Archery"],
+            "seatrade_2": ["Sailing", "Sailing", "Archery", "Climbing"],
+            "seatrade_3": ["Climbing", "Climbing", "Climbing", "Sailing"],
+            "seatrade_4": ["Kayaking", "Kayaking", "Kayaking", "Kayaking"],
+        }
+    )
+    _setup = pd.DataFrame(
+        {
+            "seatrade": ["Archery", "Sailing", "Climbing", "Kayaking"],
+            "campers_min": [0, 0, 0, 0],
+            "campers_max": [10, 10, 10, 10],
+        }
+    )
+    _config = OptimizationConfig(solver=pulp.apis.PULP_CBC_CMD(msg=0))
+
+    def _shared_sessions(self, solution, c1, c2):
+        """Columns where both campers are assigned (both == 1)."""
+        both = (solution.assignments.loc[c1] == 1) & (solution.assignments.loc[c2] == 1)
+        return [s for s in solution.assignments.columns if both[s]]
+
+    def test_friends_pair_shares_a_session(self):
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1"],
+                "camper_1": ["Alice"],
+                "cabin_2": ["Cabin1"],
+                "camper_2": ["Bob"],
+                "relationship": ["friends"],
+            }
+        )
+        problem = SchedulingProblem(self._joined, self._setup, relationships=relationships)
+
+        solution = run(problem, self._config)
+
+        assert solution.status.state == SolverState.OPTIMAL
+        # Alice=0, Bob=1 must overlap in at least one session.
+        assert len(self._shared_sessions(solution, 0, 1)) >= 1
+
+    def test_frenemies_pair_shares_no_session(self):
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1"],
+                "camper_1": ["Alice"],
+                "cabin_2": ["Cabin2"],
+                "camper_2": ["Carol"],
+                "relationship": ["frenemies"],
+            }
+        )
+        problem = SchedulingProblem(self._joined, self._setup, relationships=relationships)
+
+        solution = run(problem, self._config)
+
+        assert solution.status.state == SolverState.OPTIMAL
+        # Alice=0, Carol=2 must not overlap in any session.
+        assert self._shared_sessions(solution, 0, 2) == []
+
+    def test_contradictory_chain_is_infeasible(self):
+        # besties(Alice,Bob) → identical schedules; friends(Bob,Carol) → Carol shares
+        # a session with Bob; frenemies(Alice,Carol) → Carol shares none with Alice.
+        # Alice≡Bob, so Carol must both share and not share that schedule — infeasible.
+        relationships = pd.DataFrame(
+            {
+                "cabin_1": ["Cabin1", "Cabin1", "Cabin1"],
+                "camper_1": ["Alice", "Bob", "Alice"],
+                "cabin_2": ["Cabin1", "Cabin2", "Cabin2"],
+                "camper_2": ["Bob", "Carol", "Carol"],
+                "relationship": ["besties", "friends", "frenemies"],
+            }
+        )
+        # The set passes validation — the conflict only surfaces at solve time.
+        validate_relationships(relationships, self._joined)
+
+        problem = SchedulingProblem(self._joined, self._setup, relationships=relationships)
+        solution = run(problem, self._config)
+
+        assert solution.status.state == SolverState.INFEASIBLE
 
 
 class TestMangle:


### PR DESCRIPTION
Closes #65 · Closes #66 Closes #58.

First vertical slice of camper relationships, end-to-end: a staff member adds a relationships row in a new **Friends** tab, it is validated, and a **besties** pair is forced to receive identical schedules by the solver. This slice carries the shared plumbing (schema, validation, mock data, UI, solver wiring) but enforces only the simplest constraint (besties), which needs no auxiliary variables.