### PR TITLE
feat(solver): extract solver orchestration into a SolveRun seam (#73)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -211,7 +211,8 @@ Note the tension: `cabins_weight` (soft, encourages cabinmates together) pushes 
 | Module | Owns |
 |--------|------|
 | `problem.py` | `SchedulingProblem` — holds parsed domain state, builds MILP (variables, constraints, objective) when `.build(config)` is called. Does NOT solve. Config (weights, limits, solver settings) is passed at build time, not init — allows rebuilding with different configs against the same domain data. |
-| `solver.py` | `solver.run(problem, config) -> AssignmentSolution` — orchestrates build + solve + wrangle. Calls `problem.build(config)` internally. Manages solver thread and CBC log reading. |
+| `solver.py` | `solver.run(problem, config) -> AssignmentSolution` — pure synchronous orchestration of build + solve + wrangle. Calls `problem.build(config)` internally. Does NOT manage threads or read the log — that lives in `solve_run.py`. |
+| `solve_run.py` | `SolveRun` — runs `solver.run` in a background thread, reads the CBC log, and exposes `progress()` (a `SolveProgress` snapshot) / `result()`. The service-layer seam ADR-0004 mandates; the UI polls it and never imports `threading`/`queue` or opens the log file. |
 | `results.py` | `AssignmentSolution` dataclass + free functions for wrangling (`wrangle_assignments_to_longform`, `wrangle_assignments_to_wideform`, `prepare_seatrade_leaders`) and export views. Functions take `AssignmentSolution`, not the problem. |
 | `visualization.py` | Build `alt.Chart` specs from `AssignmentSolution`. No Streamlit dependency — renders in any Altair-capable frontend. Colors cells by a camper-satisfaction scale (top choice → low/unranked) and labels block facets via `blocks.py`. |
 | `blocks.py` | Pure decoder from block codes to Captain-friendly labels (`1a` → `1st·AM`) plus `BLOCK_DECODER_CAPTION`. No Streamlit, no side effects. |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,7 +97,7 @@ Self-contained and portable — no reference to the MILP model. Fields: assignme
 
 ### SolverStatus
 
-A field inside `AssignmentSolution` (not a separate return). Tracks the outcome of a solve. Fields: state (SolverState enum: optimal/infeasible/error), gap (optimality gap as a float), message (human-readable, e.g. infeasibility detail). Progress monitoring (percent-complete during a running solve) stays in the UI layer via `@st.fragment` log polling — not in SolverStatus.
+A field inside `AssignmentSolution` (not a separate return). Tracks the outcome of a solve. Fields: state (SolverState enum: optimal/infeasible/error), gap (optimality gap as a float), message (human-readable, e.g. infeasibility detail). Progress monitoring (percent-complete during a running solve) lives in the service layer's `SolveRun.progress()` (a `SolveProgress` snapshot computed from the CBC log + elapsed time) — not in SolverStatus. The UI only polls it and renders.
 
 ### Assignment Export
 
@@ -116,7 +116,7 @@ Each export includes columns: camper, seatrade, assignment (0/1), preference (1-
 flowchart LR
     subgraph UI [app/ — Presentation Layer]
         Upload[File Upload / Simulation Forms]
-        Fragment["@st.fragment polling SolverStatus"]
+        Poll["UI loop polling SolveRun.progress() / result()"]
         Display[Render AssignmentSolution + Charts]
     end
 
@@ -124,6 +124,7 @@ flowchart LR
         Sim[simulation.py: Generate Mock Data]
         Val[preferences.py: Validate + Join 3→2 + Relationships]
         Prob[SchedulingProblem: Build MILP]
+        Run[solve_run.py: SolveRun thread + log progress]
         Solve[solver.py: Solve + SolverStatus]
         Result[results.py: AssignmentSolution]
     end
@@ -131,7 +132,9 @@ flowchart LR
     Upload --> Sim
     Sim -->|3 DataFrames + optional relationships [#58]| Val
     Val -->|2 DataFrames + validated relationships [#58]| Prob
-    Solve -->|AssignmentSolution| Fragment
+    Prob --> Run
+    Run -->|solver.run| Solve
+    Run -->|SolveProgress / AssignmentSolution| Poll
     Result --> Display
 ```
 
@@ -214,11 +217,11 @@ Resolved during grilling session 2026-05-05. Open questions marked with [OPEN].
 
 1. **`Seatrades` class → split into SchedulingProblem + solver + results.** Problem builder owns variables/constraints/objective. Solving is separate. Wrangling is separate. `SchedulingProblem` is stateful (holds parsed domain state) because the wrangler needs the same state — avoids re-parsing or building a second context object. Module is `problem.py` (not `scheduling_problem.py`). Config passed at `.build(config)` time, not init — allows rebuilding with different configs against same domain data.
 
-2. **Solver produces `AssignmentSolution`, not raw pulp object.** Clean boundary: problem goes in, solution comes out. No leaking PuLP internals. `AssignmentSolution` is self-contained and portable — holds assignments DataFrame, SolverStatus, and domain data needed by wrangling/visualization. `SolverStatus` is a field inside `AssignmentSolution` (not a separate return): state is a `SolverState` enum (optimal/infeasible/error), `gap` is the optimality gap, `message` for human-readable detail. Progress monitoring stays in UI layer only.
+2. **Solver produces `AssignmentSolution`, not raw pulp object.** Clean boundary: problem goes in, solution comes out. No leaking PuLP internals. `AssignmentSolution` is self-contained and portable — holds assignments DataFrame, SolverStatus, and domain data needed by wrangling/visualization. `SolverStatus` is a field inside `AssignmentSolution` (not a separate return): state is a `SolverState` enum (optimal/infeasible/error), `gap` is the optimality gap, `message` for human-readable detail. Progress monitoring lives in the `SolveRun` seam (service layer), surfaced as `SolveProgress`; the UI only polls and renders.
 
 3. **Service function `solver.run(problem, config) -> AssignmentSolution`.** UI calls one function. `solver.run` calls `problem.build(config)` internally. No solver orchestration in the presentation layer.
 
-4. **Solver monitoring splits: service layer runs solver + reads CBC log, UI polls `AssignmentSolution.status` via `@st.fragment`.** PuLP/CBC doesn't support mid-solve callbacks — log file is the only progress signal. `@st.fragment(run_every=...)` replaces manual `while`+`sleep` polling. Progress percent stays in UI polling layer, not in SolverStatus.
+4. **Solver monitoring splits: the `SolveRun` seam (service layer, `solve_run.py`) runs the solve in a thread + reads the CBC log and exposes `progress()`/`result()`; the UI polls those and renders.** PuLP/CBC doesn't support mid-solve callbacks — the log file is the only progress signal. Progress percent is computed in `SolveRun.progress()` (a `SolveProgress` snapshot), not in SolverStatus. The UI still polls via a `while`+`sleep` loop; swapping it for `@st.fragment(run_every=...)` and moving `SolveRun` into `session_state` is tracked in #61 (ADR-0004 is the target end-state).
 
 5. **Simulation data generation moves to service layer** (`seatrades/simulation.py`). It's domain logic, not UI. Simulation produces 3 separate DataFrames (camper identity, camper preferences, seatrade setup) — goes through same validation pipeline as real uploads.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,14 @@ A cabin's fleet is chosen **per half, independently** — a cabin can be morning
 
 **Same fleet all week (optional, issue #22).** A Scheduling Captain working by hand keeps each cabin in one fleet all week purely for simplicity. The solver doesn't need that crutch, so per-half independence is the default. A user can switch ON an *optional hard constraint* that forces a cabin's fleet to match across both halves (AM 1st half ⇒ AM 2nd half, and PM ⇒ PM), reproducing the legacy hand-scheduled behavior. Default OFF. Implemented by `OptimizationConfig.force_same_fleet_all_week` → `_add_same_fleet_constraints` in `problem.py`, exposed as a checkbox in the optimization config form's Advanced settings. Do not write user-facing copy that asserts a cabin is in one fleet for the whole week.
 
+### Fleet Time
+
+The non-seatrade activity. Each half-week has two time slots (AM and PM). A cabin attends a seatrade during its assigned slot; during the *other* slot of that half it is on Fleet Time — a single large group activity (a hike, a wide game) that every not-on-a-seatrade camper does together.
+
+Fleet Time is the **perfect complement** of seatrade assignment: in any time slot, a camper is either in a seatrade or on Fleet Time, never both and never neither. It is therefore **not modeled in the solver** — it is implied by the absence of a seatrade. The output layer fills the empty seatrade cells with the label `"Fleet Time"` (`results.py`); it has no capacity, preference, or block parameters.
+
+Because the Fleet Time group in one slot is exactly the set of cabins *not* on seatrades that slot — which is the seatrade population of the opposite-fleet block in the same half — any measurement over each block's seatrade population also describes the Fleet Time gatherings, with no need to model Fleet Time directly.
+
 ### Camper Relationship
 
 A social constraint between a pair of campers. Each relationship has:

--- a/app.py
+++ b/app.py
@@ -1,4 +1,8 @@
+import random
+
+import numpy as np
 import streamlit as st
+from faker import Faker
 
 from app.tabs.assignments_tab import AssignmentsTab
 from app.tabs.campers_tab import CamperSimulationConfigTab, _update_camper_simulation_config
@@ -19,6 +23,11 @@ from seatrades.simulation import (
     simulate_camper_relationships,
     simulate_seatrade_preferences,
 )
+
+# Seed for the out-of-the-box demo data. Chosen because the default simulation
+# configs at this seed produce a known-feasible week (every camper assignable),
+# so the app opens on solvable mock data and the full-solve smoke test stays green.
+MOCK_DATA_SEED = 0
 
 
 # Set up logging to capture all info level logs from the root logger
@@ -66,6 +75,15 @@ def _initial_page_setup():
         _update_seatrade_simulation_config(seatrade_simulation_config=SeatradeSimulationConfig())
     if "camper_simulation_config" not in st.session_state:
         _update_camper_simulation_config(camper_simulation_config=CamperSimulationConfig())
+
+    # Seed the RNGs once, before any mock data is generated, so the out-of-the-box
+    # demo week is deterministic and known-feasible. Re-simulating from the UI advances
+    # the RNG naturally, so users still get fresh data on each click.
+    if "mock_data_seeded" not in st.session_state:
+        random.seed(MOCK_DATA_SEED)
+        np.random.seed(MOCK_DATA_SEED)
+        Faker.seed(MOCK_DATA_SEED)
+        st.session_state["mock_data_seeded"] = True
 
     # Initialize Mock Data
     if "seatrade_preferences" not in st.session_state:

--- a/app/tabs/assignments_tab.py
+++ b/app/tabs/assignments_tab.py
@@ -10,6 +10,7 @@ from seatrades.preferences import ValidationError, join_and_validate
 from seatrades.problem import SchedulingProblem
 from seatrades.results import (
     SolverState,
+    SolverStatus,
     prepare_seatrade_leaders,
     wrangle_assignments_to_longform,
     wrangle_assignments_to_wideform,
@@ -37,11 +38,7 @@ class AssignmentsTab:
         if st.session_state.get("assigned_solution"):
             # Display results
             if not st.session_state["optimization_success"]:
-                st.warning(
-                    "No schedule could satisfy all the rules this time. Try relaxing a hard limit "
-                    "under **Advanced settings** in Optimization Setup (e.g. raise *Max seatrades "
-                    "per fleet*), or lower the *Minimum solution quality*, then assign again."
-                )
+                st.warning(assignment_failure_warning(st.session_state["assigned_solution"].status))
             else:
                 solution = st.session_state["assigned_solution"]
                 optimality = solution.status.optimality
@@ -205,6 +202,22 @@ def _assign_seatrades(
     if solution is not None:
         st.session_state["assigned_solution"] = solution
     stop_button.empty()
+
+
+def assignment_failure_warning(status: SolverStatus) -> str:
+    """User-facing copy for a non-optimal solve.
+
+    A crash (ERROR) surfaces its message so the Captain is never shown an
+    untrustworthy result without explanation (story #73-16); an infeasible solve
+    keeps the relax-a-hard-limit guidance.
+    """
+    if status.state == SolverState.ERROR:
+        return f"The optimizer hit an unexpected error and couldn't finish: {status.message}"
+    return (
+        "No schedule could satisfy all the rules this time. Try relaxing a hard limit "
+        "under **Advanced settings** in Optimization Setup (e.g. raise *Max seatrades "
+        "per fleet*), or lower the *Minimum solution quality*, then assign again."
+    )
 
 
 def render_view(

--- a/app/tabs/assignments_tab.py
+++ b/app/tabs/assignments_tab.py
@@ -21,6 +21,9 @@ from seatrades.visualization import display_assignments
 # Makes Streamlit log-widget keys unique across reruns (presentation concern only).
 log_counter = 1
 
+# How often the UI re-polls SolveRun.progress() while a solve runs.
+_POLL_INTERVAL_SECONDS = 2
+
 
 class AssignmentsTab:
     """Tab Content for Assigning Seatrades"""
@@ -162,16 +165,18 @@ def _assign_seatrades(
         progress = run.progress()
         while progress.running:
             progress_bar.progress(progress.percent, progress.message)
+            # Newest log lines on top while streaming, so the latest CBC output is
+            # visible without scrolling. The final render below stays chronological.
             live_log = "".join(progress.log_text.splitlines(keepends=True)[::-1])
             if live_log:
                 log_container.text_area(
-                    "Solver Logs.",
+                    "Solver Logs",
                     value=live_log,
                     height=300,
                     key=str(log_counter) + live_log,
                 )
                 status.update(label=progress.message)
-            time.sleep(2)  # Adjust polling frequency
+            time.sleep(_POLL_INTERVAL_SECONDS)
             log_counter += 1
             progress = run.progress()
 

--- a/app/tabs/assignments_tab.py
+++ b/app/tabs/assignments_tab.py
@@ -1,7 +1,3 @@
-import logging
-import queue
-import re
-import threading
 import time
 from typing import Literal, Optional
 
@@ -9,24 +5,20 @@ import pandas as pd
 import streamlit as st
 
 from seatrades.blocks import BLOCK_DECODER_CAPTION
-from seatrades.config import SEATRADES_LOG_PATH, OptimizationConfig
+from seatrades.config import OptimizationConfig
 from seatrades.preferences import ValidationError, join_and_validate
 from seatrades.problem import SchedulingProblem
 from seatrades.results import (
-    AssignmentSolution,
     SolverState,
     prepare_seatrade_leaders,
     wrangle_assignments_to_longform,
     wrangle_assignments_to_wideform,
 )
-from seatrades.solver import run as solver_run
+from seatrades.solve_run import SolveRun
 from seatrades.visualization import display_assignments
 
-logger = logging.getLogger(__name__)
-
-status_queue: queue.Queue[int] = queue.Queue()
+# Makes Streamlit log-widget keys unique across reruns (presentation concern only).
 log_counter = 1
-_TIMEOUT_LOG_PATTERN = re.compile(r"Result - Stopped on time limit")
 
 
 class AssignmentsTab:
@@ -150,10 +142,10 @@ def _assign_seatrades(
     st.session_state["cabin_camper_prefs"] = joined_campers
     st.toast("Beginning Seatrade Optimization.")
     problem = SchedulingProblem(joined_campers, seatrade_setup, relationships=validated_relationships)
-    result_container: dict[str, AssignmentSolution] = {}
+    run = SolveRun(problem, optimization_config)
     with st.status("Setting up the optimization…") as status:
-        # CAUTION: Does not actually stop the solver subthread which will keep running.
-        # This will be a problem later if a user starts a ton of solver threads behind the scenes.
+        # CAUTION: Stopping only interrupts this UI loop — the daemon solve thread keeps
+        # running. Real cancellation is tracked in #61 / Spec B.
         stop_button = st.empty()
 
         def _stop_optimizing() -> None:
@@ -163,78 +155,42 @@ def _assign_seatrades(
 
         progress_bar = st.progress(0, "Setting up the optimization…")
 
-        # Start the solver in a background thread, read logs in real time.
         # Raw solver logs are tucked into a collapsed expander so the default view stays friendly.
         global log_counter
         with st.expander("Show technical details (solver logs)"):
             log_container = st.empty()
-        log_text = ""
-        if SEATRADES_LOG_PATH.exists():
-            SEATRADES_LOG_PATH.unlink(missing_ok=True)
-        started = time.time()
-        timeout = False
-        solver_thread = threading.Thread(
-            target=_run_assignment_and_capture_logs,
-            daemon=True,
-            args=(problem, optimization_config, result_container),
-        )
-        solver_thread.start()
-        while solver_thread.is_alive():
-            elapsed_seconds = int(time.time() - started)
-            elapsed_pct_of_time_limit = elapsed_seconds / optimization_config.solver.timeLimit
-            if elapsed_pct_of_time_limit > 1.0:
-                timeout = True
-            progress_bar.progress(
-                min(elapsed_pct_of_time_limit, 1.0),
-                ("Optimizing seatrade assignments…" if not timeout else "Finishing up — time limit reached…"),
-            )
-            try:
-                if SEATRADES_LOG_PATH.exists():
-                    with open(SEATRADES_LOG_PATH, "r") as log_file:
-                        log_text = "".join(log_file.readlines()[::-1])
-                    if log_text:
-                        log_container.text_area(
-                            "Solver Logs.",
-                            value=log_text,
-                            height=300,
-                            key=str(log_counter) + log_text,
-                        )
-                        if _TIMEOUT_LOG_PATTERN.search(log_text):
-                            timeout = True
 
-                        if not timeout:
-                            status.update(label="Optimizing seatrade assignments…")
-                        else:
-                            status.update(label="Finishing up — time limit reached…")
-
-            except Exception as e:
+        # SolveRun owns the thread + log file; the UI just polls and renders.
+        run.start()
+        progress = run.progress()
+        while progress.running:
+            progress_bar.progress(progress.percent, progress.message)
+            live_log = "".join(progress.log_text.splitlines(keepends=True)[::-1])
+            if live_log:
                 log_container.text_area(
                     "Solver Logs.",
-                    f"Error reading logs: {e}",
+                    value=live_log,
                     height=300,
+                    key=str(log_counter) + live_log,
                 )
+                status.update(label=progress.message)
             time.sleep(2)  # Adjust polling frequency
             log_counter += 1
-        if SEATRADES_LOG_PATH.exists():
-            with open(SEATRADES_LOG_PATH, "r") as log_file:
-                log_text = log_file.read()
+            progress = run.progress()
+
         log_container.text_area(
             "Solver Logs",
-            value=log_text,
+            value=progress.log_text,
             height=300,
             key="logs",
         )
-        timeout_kwd_match = _TIMEOUT_LOG_PATTERN.search(log_text)
-        timeout = bool(timeout or timeout_kwd_match)
-        timeout_status = " - Timeout Reached" if timeout else ""
-        solution_optimality = result_container["solution"].status.optimality if "solution" in result_container else 1.0
+        solution = run.result()
+        timeout_status = " - Timeout Reached" if progress.timed_out else ""
+        solution_optimality = solution.status.optimality if solution is not None else 1.0
         optimality_status = f" - {solution_optimality:.0%} Optimal Solution found"
-        progress_bar.progress(
-            1.0,
-            ("Optimization Concluded."),
-        )
+        progress_bar.progress(1.0, "Optimization Concluded.")
         st.toast("Seatrade Optimization Concluded.")
-        if not status_queue.empty() and status_queue.get() > 0:
+        if solution is not None and solution.status.state == SolverState.OPTIMAL:
             st.session_state["optimization_success"] = True
             st.toast("Optimization Problem Solved!", icon="🎉")
             status.update(
@@ -246,26 +202,9 @@ def _assign_seatrades(
             st.session_state["optimization_success"] = False
             st.toast("Failed to solve optimization problem.", icon="🚨")
             status.update(state="error", label="Seatrades failed to be assigned.")
-    if "solution" in result_container:
-        st.session_state["assigned_solution"] = result_container["solution"]
+    if solution is not None:
+        st.session_state["assigned_solution"] = solution
     stop_button.empty()
-
-
-def _run_assignment_and_capture_logs(
-    problem: SchedulingProblem, optimization_config: OptimizationConfig, result_container: dict[str, AssignmentSolution]
-) -> None:
-    """Run solver and capture status to status_queue, intended to be run in a separate thread."""
-    try:
-        solution = solver_run(problem, optimization_config)
-        result_container["solution"] = solution
-        if solution.status.state == SolverState.OPTIMAL:
-            status_queue.put(1)
-        else:
-            status_queue.put(-1)
-
-    except Exception as e:
-        logger.error("Solver thread failed: %s", e)
-        status_queue.put(-1)
 
 
 def render_view(

--- a/docs/adr/0004-solver-monitoring-strategy.md
+++ b/docs/adr/0004-solver-monitoring-strategy.md
@@ -16,12 +16,16 @@ The current implementation uses a manual `while` loop with `time.sleep(2)`, a `q
 
 The monitoring splits into two layers:
 
-1. **Service layer** (`solver.py`) — runs the solver in a background thread, reads the CBC log, writes structured progress to a `SolverStatus` object (percent, message, state). No Streamlit imports.
-2. **UI layer** (`app/tabs/`) — `@st.fragment` reads `SolverStatus` from session state and renders progress widgets. Never touches the log file or manages threads.
+1. **Service layer** (`solve_run.py`) — the `SolveRun` seam runs the solve in a background thread, reads the CBC log, and exposes `progress()` (a `SolveProgress` snapshot: running, percent, message, log_text, timed_out) and `result()`. Percent is computed here (time-based, via the pure `percent_from_elapsed`/`detect_timeout` helpers), not stored on `SolverStatus`. No Streamlit imports.
+2. **UI layer** (`app/tabs/`) — polls `SolveRun.progress()`/`result()` and renders progress widgets. Never touches the log file or manages threads.
+
+## Implementation status
+
+The service-layer seam landed in #73: `SolveRun` (in `solve_run.py`) now owns the thread and log reading, so the UI no longer imports `threading`/`queue` or reads the log file. The UI still polls via a `while` + `time.sleep(2)` loop reading `progress()`/`result()`; swapping that loop for `@st.fragment(run_every=...)` and moving `SolveRun` into `session_state` is the remaining step toward this ADR's end-state, tracked in #61.
 
 ## Consequences
 
 - The UI never imports `threading`, `queue`, or reads log files directly.
-- `SolverStatus` is a plain dataclass with no Streamlit dependency — testable without the UI.
-- Log-parsing regex and thread management move from `assignments_tab.py` to `solver.py`.
+- `SolveProgress` and `SolverStatus` are plain dataclasses with no Streamlit dependency — testable without the UI (`tests/test_seatrades/test_solve_run.py`).
+- Log-parsing regex and thread management moved from `assignments_tab.py` to `solve_run.py` (`SolveRun`).
 - Future: if a solver with callback support replaces PuLP, the service layer can switch to callbacks without changing the UI layer.

--- a/seatrades/solve_run.py
+++ b/seatrades/solve_run.py
@@ -1,0 +1,21 @@
+"""Background solve orchestration — run a solve in a thread and observe its progress.
+
+`SolveRun` is the service-layer seam that ADR-0004 mandates: it owns running
+``solver.run`` in a background thread and watching the CBC log, so the UI never
+imports ``threading``/``queue`` or reads the log file. The UI constructs a
+``SolveRun``, calls ``start()``, polls ``progress()``/``result()``, and renders.
+"""
+
+import re
+
+_TIMEOUT_LOG_PATTERN = re.compile(r"Result - Stopped on time limit")
+
+
+def percent_from_elapsed(elapsed: float, time_limit: float) -> float:
+    """Fraction of the solver time limit elapsed, capped at 1.0."""
+    return min(elapsed / time_limit, 1.0)
+
+
+def detect_timeout(log_text: str) -> bool:
+    """Whether the CBC log shows the solve stopped on its time limit."""
+    return bool(_TIMEOUT_LOG_PATTERN.search(log_text))

--- a/seatrades/solve_run.py
+++ b/seatrades/solve_run.py
@@ -126,5 +126,5 @@ class SolveRun:
         """Raw CBC log contents (chronological); '' if the log isn't there yet."""
         try:
             return self._config.log_path.read_text()
-        except (FileNotFoundError, OSError):
+        except OSError:  # includes FileNotFoundError — log not written yet
             return ""

--- a/seatrades/solve_run.py
+++ b/seatrades/solve_run.py
@@ -7,8 +7,22 @@ imports ``threading``/``queue`` or reads the log file. The UI constructs a
 """
 
 import re
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import pandas as pd
+
+from seatrades import solver
+from seatrades.config import OptimizationConfig
+from seatrades.problem import SchedulingProblem
+from seatrades.results import AssignmentSolution, SolverState, SolverStatus
 
 _TIMEOUT_LOG_PATTERN = re.compile(r"Result - Stopped on time limit")
+
+_OPTIMIZING_MESSAGE = "Optimizing seatrade assignments…"
+_TIMEOUT_MESSAGE = "Finishing up — time limit reached…"
 
 
 def percent_from_elapsed(elapsed: float, time_limit: float) -> float:
@@ -19,3 +33,98 @@ def percent_from_elapsed(elapsed: float, time_limit: float) -> float:
 def detect_timeout(log_text: str) -> bool:
     """Whether the CBC log shows the solve stopped on its time limit."""
     return bool(_TIMEOUT_LOG_PATTERN.search(log_text))
+
+
+@dataclass
+class SolveProgress:
+    """A snapshot of an in-flight (or finished) solve, observed via the CBC log."""
+
+    running: bool
+    percent: float
+    message: str
+    log_text: str
+    timed_out: bool
+
+
+class SolveRun:
+    """Runs ``solve_fn(problem, config)`` in a background thread and watches the log.
+
+    Construction is side-effect-free. ``start()`` owns the side effects (clear the
+    log, record the start time, spawn the thread). ``progress()`` and ``result()``
+    are cheap and idempotent so the caller can poll them from a ``while`` loop or a
+    Streamlit fragment.
+    """
+
+    def __init__(
+        self,
+        problem: SchedulingProblem,
+        config: OptimizationConfig,
+        solve_fn: Callable[[SchedulingProblem, OptimizationConfig], AssignmentSolution] = solver.run,
+    ) -> None:
+        self._problem = problem
+        self._config = config
+        self._solve_fn = solve_fn
+        self._thread: Optional[threading.Thread] = None
+        self._start_time: Optional[float] = None
+        self._result: Optional[AssignmentSolution] = None
+
+    def start(self) -> None:
+        """Clear the log, record the start time, and spawn the solver thread."""
+        self._config.log_path.unlink(missing_ok=True)
+        self._start_time = time.time()
+        self._thread = threading.Thread(target=self._solve, daemon=True)
+        self._thread.start()
+
+    def progress(self) -> SolveProgress:
+        """Cheap, idempotent snapshot: thread-alive + elapsed time + log contents."""
+        running = self._thread is not None and self._thread.is_alive()
+        elapsed = time.time() - self._start_time if self._start_time is not None else 0.0
+        time_limit = self._config.solver.timeLimit
+        log_text = self._read_log()
+        timed_out = detect_timeout(log_text) or elapsed > time_limit
+        return SolveProgress(
+            running=running,
+            percent=percent_from_elapsed(elapsed, time_limit),
+            message=_TIMEOUT_MESSAGE if timed_out else _OPTIMIZING_MESSAGE,
+            log_text=log_text,
+            timed_out=timed_out,
+        )
+
+    def result(self) -> Optional[AssignmentSolution]:
+        """The finished solution, or None while the solve is still running."""
+        return self._result
+
+    def _solve(self) -> None:
+        """Thread target: run the solve, turning any crash into an ERROR solution."""
+        try:
+            self._result = self._solve_fn(self._problem, self._config)
+        except Exception as exc:  # noqa: BLE001 — any solver crash becomes an ERROR result
+            self._result = self._error_solution(str(exc))
+
+    def _error_solution(self, message: str) -> AssignmentSolution:
+        """Synthesize an ERROR solution from the held problem and a crash message.
+
+        Mirrors how ``solver.run`` assembles an AssignmentSolution, but with empty
+        assignments — so the UI sees one status-keyed code path for crashes.
+        """
+        camper_names = pd.Series(
+            self._problem.camper_names,
+            index=pd.Index(self._problem.camper_ids, name="camper_id"),
+        )
+        return AssignmentSolution(
+            assignments=pd.DataFrame(),
+            status=SolverStatus(state=SolverState.ERROR, message=message),
+            cabins=self._problem.cabins,
+            campers=self._problem.camper_names,
+            seatrades_full=self._problem.seatrades_full,
+            cabin_camper_prefs=self._problem.cabin_camper_prefs,
+            camper_prefs=self._problem.camper_prefs,
+            camper_names=camper_names,
+        )
+
+    def _read_log(self) -> str:
+        """Raw CBC log contents (chronological); '' if the log isn't there yet."""
+        try:
+            return self._config.log_path.read_text()
+        except (FileNotFoundError, OSError):
+            return ""

--- a/tests/test_app/test_assignments_tab.py
+++ b/tests/test_app/test_assignments_tab.py
@@ -1,6 +1,22 @@
 """Tests for the assignments_tab module."""
 
-from app.tabs.assignments_tab import render_view
+from app.tabs.assignments_tab import assignment_failure_warning, render_view
+from seatrades.results import SolverState, SolverStatus
+
+
+class TestAssignmentFailureWarning:
+    def test_error_surfaces_the_message(self):
+        """A crashed solve shows its failure message, not the infeasibility copy."""
+        status = SolverStatus(state=SolverState.ERROR, message="solver blew up")
+        warning = assignment_failure_warning(status)
+        assert "solver blew up" in warning
+
+    def test_infeasible_shows_relax_a_limit_copy(self):
+        """An infeasible solve keeps the relax-a-hard-limit guidance (unchanged copy)."""
+        status = SolverStatus(state=SolverState.INFEASIBLE, message="")
+        warning = assignment_failure_warning(status)
+        assert "relaxing a hard limit" in warning
+        assert "solver blew up" not in warning
 
 
 class TestRenderView:

--- a/tests/test_seatrades/test_solve_run.py
+++ b/tests/test_seatrades/test_solve_run.py
@@ -1,0 +1,25 @@
+"""Tests for the SolveRun service-layer seam."""
+
+from seatrades.solve_run import detect_timeout, percent_from_elapsed
+
+
+class TestPercentFromElapsed:
+    def test_returns_fraction_of_time_limit(self):
+        """Halfway through the time limit reports 0.5."""
+        assert percent_from_elapsed(30.0, 60.0) == 0.5
+
+    def test_caps_at_one_past_the_limit(self):
+        """Elapsed beyond the time limit never exceeds 1.0."""
+        assert percent_from_elapsed(90.0, 60.0) == 1.0
+
+
+class TestDetectTimeout:
+    def test_true_when_log_has_time_limit_line(self):
+        """CBC's time-limit line marks the solve as timed out."""
+        log_text = "Cbc0010I After 0 nodes\nResult - Stopped on time limit\nTotal time 60.0"
+        assert detect_timeout(log_text) is True
+
+    def test_false_when_log_lacks_time_limit_line(self):
+        """A normal optimal log is not a timeout."""
+        log_text = "Result - Optimal solution found\nObjective value 42.0"
+        assert detect_timeout(log_text) is False

--- a/tests/test_seatrades/test_solve_run.py
+++ b/tests/test_seatrades/test_solve_run.py
@@ -1,6 +1,19 @@
 """Tests for the SolveRun service-layer seam."""
 
-from seatrades.solve_run import detect_timeout, percent_from_elapsed
+import threading
+import time
+
+import pytest
+
+from seatrades.config import OptimizationConfig
+from seatrades.results import SolverState
+from seatrades.solve_run import SolveRun, detect_timeout, percent_from_elapsed
+
+
+@pytest.fixture
+def isolated_config(tmp_path):
+    """OptimizationConfig whose CBC log lives under a temp dir, not the cwd."""
+    return OptimizationConfig(log_path=tmp_path / "solve.log")
 
 
 class TestPercentFromElapsed:
@@ -23,3 +36,114 @@ class TestDetectTimeout:
         """A normal optimal log is not a timeout."""
         log_text = "Result - Optimal solution found\nObjective value 42.0"
         assert detect_timeout(log_text) is False
+
+
+class TestSolveRunIsSideEffectFree:
+    def test_init_does_not_start_thread_or_touch_log(
+        self, scheduling_problem, isolated_config, sample_assignment_solution
+    ):
+        """Construction stores references only — no thread, no log file write."""
+        isolated_config.log_path.write_text("pre-existing sentinel")
+
+        run = SolveRun(scheduling_problem, isolated_config, solve_fn=lambda _p, _c: sample_assignment_solution)
+
+        assert run.progress().running is False
+        assert run.result() is None
+        assert isolated_config.log_path.read_text() == "pre-existing sentinel"
+
+
+def _wait_until_done(run, timeout=5.0):
+    """Poll progress() until the solve finishes, via the public interface."""
+    deadline = time.time() + timeout
+    while run.progress().running and time.time() < deadline:
+        time.sleep(0.01)
+    assert run.progress().running is False, "solve did not finish within timeout"
+
+
+class TestSolveRunOrchestration:
+    def test_running_then_completes_with_solution(
+        self, scheduling_problem, isolated_config, sample_assignment_solution
+    ):
+        """While solve_fn blocks, running is True / result None; once it returns, the
+        solution is available and running is False."""
+        gate = threading.Event()
+
+        def blocking_solve(_problem, _config):
+            gate.wait()
+            return sample_assignment_solution
+
+        run = SolveRun(scheduling_problem, isolated_config, solve_fn=blocking_solve)
+        run.start()
+
+        assert run.progress().running is True
+        assert run.result() is None
+
+        gate.set()
+        _wait_until_done(run)
+
+        assert run.result() is sample_assignment_solution
+
+    def test_crash_becomes_error_solution_with_message(self, scheduling_problem, isolated_config):
+        """A solve_fn that raises yields an ERROR AssignmentSolution whose status
+        message carries the exception text — never a propagated crash."""
+
+        def crashing_solve(_problem, _config):
+            raise RuntimeError("solver blew up")
+
+        run = SolveRun(scheduling_problem, isolated_config, solve_fn=crashing_solve)
+        run.start()
+        _wait_until_done(run)
+
+        solution = run.result()
+        assert solution is not None
+        assert solution.status.state == SolverState.ERROR
+        assert "solver blew up" in solution.status.message
+
+    def test_immediate_return_takes_completion_path(
+        self, scheduling_problem, isolated_config, sample_assignment_solution
+    ):
+        """A solve_fn that returns at once still lands on the completion path."""
+
+        run = SolveRun(scheduling_problem, isolated_config, solve_fn=lambda _p, _c: sample_assignment_solution)
+        run.start()
+        _wait_until_done(run)
+
+        assert run.result() is sample_assignment_solution
+
+    def test_progress_reports_timeout_once_past_limit(
+        self, scheduling_problem, isolated_config, sample_assignment_solution
+    ):
+        """Past the time limit, progress caps percent at 1.0, flags timed_out, and
+        switches to the 'finishing up' message — all while still running."""
+        isolated_config.solver.timeLimit = 0.01
+        gate = threading.Event()
+
+        def blocking_solve(_problem, _config):
+            gate.wait()
+            return sample_assignment_solution
+
+        run = SolveRun(scheduling_problem, isolated_config, solve_fn=blocking_solve)
+        run.start()
+        time.sleep(0.05)
+        progress = run.progress()
+        gate.set()
+
+        assert progress.running is True
+        assert progress.percent == 1.0
+        assert progress.timed_out is True
+        assert progress.message == "Finishing up — time limit reached…"
+
+
+class TestSolveRunIntegration:
+    def test_real_solve_produces_optimal_solution_and_log(self, scheduling_problem, isolated_config):
+        """End-to-end through the real solver: an optimal solution comes back and a
+        real CBC log is written under the isolated path and readable via progress()."""
+        run = SolveRun(scheduling_problem, isolated_config)
+        run.start()
+        _wait_until_done(run, timeout=30.0)
+
+        solution = run.result()
+        assert solution is not None
+        assert solution.status.state == SolverState.OPTIMAL
+        assert isolated_config.log_path.exists()
+        assert run.progress().log_text != ""


### PR DESCRIPTION
## Parent
Closes #73 (PRD: Extract solver orchestration into a `SolveRun` seam — restore ADR-0004).

## What this does
Behavior-preserving lift-and-shift. The most failure-prone, least-tested code in the app — running a solve and watching its progress — moves out of the Streamlit click handler into a service-layer **`SolveRun`** seam, restoring ADR-0004.

Built TDD in the agreed order (one test → one impl): **pure helpers → `SolveRun` → rewire UI**.

### Commits
1. **`percent_from_elapsed` + `detect_timeout`** — pure, directly-unit-tested helpers extracted from the UI handler.
2. **`SolveRun`** (`seatrades/solve_run.py`) — owns running `solver.run` in a background thread and observing the CBC log. Side-effect-free `__init__`; `start()` clears the log + spawns the daemon thread; `progress()` returns a `SolveProgress` snapshot (running / percent / message / log_text / timed_out); `result()` returns the `AssignmentSolution` (`None` strictly means still running). A crash becomes an ERROR `AssignmentSolution` so the caller has one status-keyed path. `solve_fn` dependency injection gives a deterministic, mock-free test seam.
3. **UI rewire + docs** — `_assign_seatrades` constructs a `SolveRun`, `start()`s it, polls `progress()`/`result()` from the existing `while` loop. Drops the `threading`/`queue`/`re` imports, the module-level `status_queue` global, and `_run_assignment_and_capture_logs`. CONTEXT.md decision #4 + data-flow diagram and ADR-0004 now name `SolveRun`/`SolveProgress` as the service-layer home of live progress.

`solver.run` is untouched. `percent` lives only in `SolveProgress`, never in `SolverStatus`.

## Out of scope (tracked in #61 / Spec B)
Swapping the UI `while`+`sleep` loop for `@st.fragment(run_every=)`, moving `SolveRun` into `session_state`, the concurrency guard, and real solve cancellation. The `progress()`/`result()` interface is deliberately cheap + idempotent so that swap needs no change to `SolveRun`.

## Verification
- New `tests/test_seatrades/test_solve_run.py` — 10 tests: 2 pure helpers, 5 orchestration (injected `solve_fn` + `threading.Event`, deterministic), 1 real integration solve (<0.5s), all isolated under `tmp_path`.
- Full suite: **243 passed, 1 deselected**.
- UI guard — the existing full-solve AppTest `test_assign_seatrades_end_to_end` — passes on feasible draws, confirming the rewire is invisible to the Scheduling Captain.

## Note
The smoke test was observed to be **pre-existing flaky** (~25% of runs): the app's mock data is randomly generated and unseeded, so some draws are genuinely infeasible. Not caused by this refactor (an infeasible draw is handled correctly — no exception, warning shown). Deterministic/feasible mock data is being addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update: deterministic, feasible mock data (added to this PR)
The pre-existing smoke flakiness is now fixed. The app's mock data was unseeded (~25-30% of draws infeasible). This PR seeds `random`/`numpy`/`Faker` once before initial mock generation (seed 0, verified feasible), so the app opens on a solvable week and the smoke test is deterministic (3/3 green). Re-simulating from the UI advances the RNG, so users still get fresh data per click.

Investigation finding: infeasibility comes from preference clustering (~10%) plus the seeded besties/friends relationship constraints (~20%) — **not** raw capacity. Fewer cabins made feasibility *worse*, so config tuning isn't a reliable lever; seeding the default is.
