### PR TITLE
VIZ: ghost preference numbers for unassigned seatrades (#85)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,7 +124,13 @@ The app exports assignments in 2 formats for different audiences:
 | Captain's Book | Camper (Cabin upload order) | Internal logistics and bookkeeping, Distribute to cabin leaders for their campers |
 | Seatrade Leaders | Block → Seatrade → Cabin → Camper | Day-of attendance at each seatrade session |
 
-Each export includes columns: camper, seatrade, assignment (0/1), preference (1-4), cabin, block.
+Each row carries: camper, seatrade, `assignment` (0/1), `preference_rank`, `assigned_to_block`, cabin, block.
+
+The longform (`wrangle_assignments_to_longform`) decomposes what was once a single conflated `preference` column into orthogonal facts (issue #85, [ADR 0010](docs/adr/0010-decompose-preference-into-orthogonal-facts.md)):
+
+- **`assignment`** (0/1) — did this camper get *this* seatrade cell?
+- **`preference_rank`** — the rank the camper *gave* this seatrade (1–4), else `999` (`UNMATCHED_PREFERENCE`) for unranked. A pure camper↔seatrade fact populated on **every** cell, so the rank a camper gave a seatrade they *didn't* get stays recoverable.
+- **`assigned_to_block`** (bool) — does this camper have *any* seatrade this block, vs being on Fleet Time? A schedule fact about the whole block, distinct from `assignment` (one cell).
 
 ## Data Flow
 

--- a/app/tabs/assignments_tab.py
+++ b/app/tabs/assignments_tab.py
@@ -155,6 +155,7 @@ class AssignmentsTab:
                 st.altair_chart(results_chart)
                 st.caption(f"Blocks: {BLOCK_DECODER_CAPTION}")
                 st.caption("Color = camper satisfaction (green = 1st choice pick → red = lower ranked choices). ")
+                st.caption("Numbers indicate camper-submitted seatrade preferences.")
 
                 # Schedule Quality — the report card. One slot: Overview summary or a
                 # single metric's drill-down, never both. Only reached on an optimal solve.

--- a/docs/adr/0010-decompose-preference-into-orthogonal-facts.md
+++ b/docs/adr/0010-decompose-preference-into-orthogonal-facts.md
@@ -1,0 +1,55 @@
+# Decompose the conflated `preference` column into orthogonal facts
+
+The longform assignments frame (`wrangle_assignments_to_longform`) once carried a single
+`preference` column that conflated three unrelated things. Issue #85 decomposes it into
+orthogonal `assignment` + `preference_rank` facts, plus a derived `assigned_to_block` schedule fact.
+
+**Status: accepted**
+
+## Context
+
+The old `preference` column overloaded one integer with three meanings:
+
+- `0` — the camper was **not assigned** this cell (regardless of what they ranked).
+- `1–4` — the camper was **assigned** this cell **and** had ranked it at that position.
+- `999` (`UNMATCHED_PREFERENCE`) — the camper was **assigned** this cell but never ranked it.
+
+Because unassigned was forced to `0`, the rank a camper *gave* a seatrade they *didn't get* was
+unrecoverable. That hid near-misses — most visibly, a group who submitted the same preferences so
+they could be together but got split by the solver: nothing on the master grid showed the group was
+*nearly* kept whole (issue #85).
+
+## Decision
+
+Replace the conflated column with orthogonal facts:
+
+- **`assignment`** (0/1) — did this camper get *this* seatrade cell? Unchanged.
+- **`preference_rank`** — the rank the camper gave this seatrade (`1–4`), else `999`
+  (`UNMATCHED_PREFERENCE`) for unranked. Populated on **every** cell regardless of assignment or
+  block — a pure camper↔seatrade fact. Stays a plain `int` reusing the existing `999` sentinel (no
+  `pd.NA`).
+- **`assigned_to_block`** (bool) — does this camper have *any* real seatrade in this block (vs Fleet
+  Time)? Derived by grouping `assignment` over `(camper_id, block)`. A schedule fact about the whole
+  block, deliberately distinct from `assignment`, which is about one cell.
+
+The old `preference` column is **removed entirely** — keeping it alongside the new columns would
+reintroduce the very conflation this decision removes.
+
+"Where to paint faint ink" (the ghost-number display rule) is **not** a data-layer concern. The
+data layer carries only domain facts; the chart layer (`enrich_assignments_for_display` in
+`visualization.py`) derives the display columns (`satisfaction`, `rank_text`, `ghost_text`) from
+those facts as a pure, unit-testable helper.
+
+## Consequences
+
+- The master camper grid can draw a camper's rank for seatrades they were *not* assigned, faintly,
+  in the blocks they attend — surfacing split same-preference groups. The ghost rule is
+  `preference_rank ∈ 1..4 AND assignment == 0 AND assigned_to_block`.
+- The assigned layer's Altair filter flips from `preference > 0` to `assignment == 1`. Required:
+  now that unassigned cells carry real ranks, `preference > 0` would mis-colour a ghost cell as a
+  real placement. Assigned cells render identically.
+- Callers that read the old column moved to `preference_rank` (e.g. `scoring._camper_cprs`, which
+  only ever looks at assigned rows, where `preference_rank` equals the old `preference`).
+- **Future refactors must not re-collapse these columns "for simplicity."** The orthogonality is
+  the point — the split is what makes the "didn't get" rank recoverable and the Fleet-Time-vs-
+  seatrade distinction testable at a clear seam.

--- a/docs/adr/0010-decompose-preference-into-orthogonal-facts.md
+++ b/docs/adr/0010-decompose-preference-into-orthogonal-facts.md
@@ -36,7 +36,7 @@ The old `preference` column is **removed entirely** — keeping it alongside the
 reintroduce the very conflation this decision removes.
 
 "Where to paint faint ink" (the ghost-number display rule) is **not** a data-layer concern. The
-data layer carries only domain facts; the chart layer (`enrich_assignments_for_display` in
+data layer carries only domain facts; the chart layer (`add_display_columns` in
 `visualization.py`) derives the display columns (`satisfaction`, `rank_text`, `ghost_text`) from
 those facts as a pure, unit-testable helper.
 

--- a/seatrades/results.py
+++ b/seatrades/results.py
@@ -76,16 +76,20 @@ def wrangle_assignments_to_longform(solution: AssignmentSolution) -> pd.DataFram
     assignments = solution.assignments
     df = assignments.melt(var_name="seatrade", ignore_index=False, value_name="assignment").reset_index()
 
-    def lookup_preference(row) -> int:
-        if row.assignment == 1.0:
-            row_camper_prefs = solution.camper_prefs[row.camper_id]
-            seatrade_name = row.seatrade.split("_", 1)[1]
-            if seatrade_name in row_camper_prefs:
-                return row_camper_prefs.index(seatrade_name) + 1
-            return UNMATCHED_PREFERENCE
-        return 0
+    def lookup_preference_rank(row) -> int:
+        """The rank this camper GAVE this seatrade — a pure camper↔seatrade fact.
 
-    df["preference"] = df.apply(lookup_preference, axis=1)
+        Populated on every cell regardless of assignment or block, so the rank a camper
+        gave a seatrade they *didn't* get stays recoverable. ``UNMATCHED_PREFERENCE`` for a
+        seatrade they never ranked (most cells, since each camper ranks only 4 seatrades).
+        """
+        row_camper_prefs = solution.camper_prefs[row.camper_id]
+        seatrade_name = row.seatrade.split("_", 1)[1]
+        if seatrade_name in row_camper_prefs:
+            return row_camper_prefs.index(seatrade_name) + 1
+        return UNMATCHED_PREFERENCE
+
+    df["preference_rank"] = df.apply(lookup_preference_rank, axis=1)
 
     def lookup_cabin(row) -> Optional[str]:
         if row.camper_id in solution.cabin_camper_prefs.index:
@@ -95,8 +99,14 @@ def wrangle_assignments_to_longform(solution: AssignmentSolution) -> pd.DataFram
     df["cabin"] = df.apply(lookup_cabin, axis=1)  # type: ignore[call-overload]
     df["age"] = df["camper_id"].map(solution.cabin_camper_prefs["age"])
     df["camper"] = df["camper_id"].map(solution.camper_names)
-    df = df.drop(columns="camper_id")
     df[["block", "seatrade"]] = df["seatrade"].str.split("_", expand=True)
+
+    # A schedule fact, distinct from ``assignment`` (one cell): does this camper have *any*
+    # real seatrade in this block, vs being on Fleet Time? Grouped on camper_id (names collide),
+    # so it is uniform across all of a (camper, block)'s seatrade cells.
+    df["assigned_to_block"] = df.groupby(["camper_id", "block"])["assignment"].transform("max") == 1.0
+
+    df = df.drop(columns="camper_id")
 
     return df
 

--- a/seatrades/scoring.py
+++ b/seatrades/scoring.py
@@ -115,7 +115,7 @@ def _camper_cprs(assigned: pd.DataFrame) -> pd.DataFrame:
     ``cpr`` (3–6). Assigned rows carry a 1–4 preference by the top-2 guarantee and
     the preference-only constraint, so the two-block sum lands in 3–6.
     """
-    grouped = assigned.groupby(["cabin", "camper"], sort=False)["preference"]
+    grouped = assigned.groupby(["cabin", "camper"], sort=False)["preference_rank"]
     detail = grouped.agg(cpr="sum", ranks=list).reset_index()
     detail["cause"] = detail["ranks"].map(lambda ranks: f"{min(ranks)}+{max(ranks)}")
     return detail.drop(columns="ranks")

--- a/seatrades/visualization.py
+++ b/seatrades/visualization.py
@@ -493,7 +493,7 @@ def _ghost_text(preference_rank: int, assignment: float, assigned_to_block: bool
     return ""
 
 
-def enrich_assignments_for_display(longform_df: pd.DataFrame) -> pd.DataFrame:
+def add_display_columns(longform_df: pd.DataFrame) -> pd.DataFrame:
     """Add the chart's display columns to a longform frame, without rendering anything.
 
     The data layer carries only domain facts (``assignment``, ``preference_rank``,
@@ -596,7 +596,7 @@ def display_assignments(solution: AssignmentSolution) -> alt.Chart:
         )
 
     longform_df = wrangle_assignments_to_longform(solution)
-    longform_df = enrich_assignments_for_display(longform_df)
+    longform_df = add_display_columns(longform_df)
     longform_df["block"] = longform_df["block"].map(block_label)
 
     assignment_base = alt.Chart(longform_df).encode(

--- a/seatrades/visualization.py
+++ b/seatrades/visualization.py
@@ -56,6 +56,10 @@ SATISFACTION_RANGE = ["#1a9850", "#91cf60", "#fee08b", "#fc8d59", "#d73027"]
 # Neutral fill for cells a camper is not assigned, so the grid stays visible on a dark app theme.
 UNASSIGNED_COLOR = "#99C2DF"
 
+# Opacity of the faint ghost ranks (unassigned-but-ranked cells). The one tuning knob for
+# ghost legibility on the dark theme — quiet enough not to compete with the bold assigned ranks.
+GHOST_TEXT_OPACITY = 0.3
+
 # Cohesion detail: red↔green on the *quality* (not the block) — a camper alone in a session is bad
 # (red), with any cabinmate is good (green). Blocks still ride ``detail`` so they split on the
 # tooltip; the colour just reads the x-axis level so the eye lands on the right conclusion.
@@ -480,11 +484,11 @@ def _ghost_text(preference_rank: int, assignment: float, assigned_to_block: bool
     """The faint rank to print on an *unassigned* cell — else blank.
 
     Drawn iff the camper ranked this seatrade (``preference_rank`` ∈ 1..4), did NOT get it
-    here (``assignment == 0``), and is on a seatrade this block (``assigned_to_block``). This
+    here (``assignment == 0.0``), and is on a seatrade this block (``assigned_to_block``). This
     surfaces near-misses — e.g. a same-preference group the solver split — without touching
     Fleet Time blocks or unranked cells.
     """
-    if preference_rank != UNMATCHED_PREFERENCE and assignment == 0 and assigned_to_block:
+    if preference_rank != UNMATCHED_PREFERENCE and assignment == 0.0 and assigned_to_block:
         return str(preference_rank)
     return ""
 
@@ -618,7 +622,7 @@ def display_assignments(solution: AssignmentSolution) -> alt.Chart:
     # neutral background (no tint), so it never reads as a real placement. Opacity is the one
     # tuning knob, set during visual verification.
     ghost_cells = assignment_base.transform_filter(alt.datum.ghost_text != "")
-    assignment_ghost_text = ghost_cells.mark_text(color="black", opacity=0.3).encode(text="ghost_text:N")
+    assignment_ghost_text = ghost_cells.mark_text(color="black", opacity=GHOST_TEXT_OPACITY).encode(text="ghost_text:N")
     assignment_chart = (
         (assignment_background + assignment_rectangles + assignment_text + assignment_ghost_text)
         .facet(row="cabin", column="block", spacing={"row": 2})

--- a/seatrades/visualization.py
+++ b/seatrades/visualization.py
@@ -476,6 +476,40 @@ def _rank_text(preference: int) -> str:
     return str(preference)
 
 
+def _ghost_text(preference_rank: int, assignment: float, assigned_to_block: bool) -> str:
+    """The faint rank to print on an *unassigned* cell — else blank.
+
+    Drawn iff the camper ranked this seatrade (``preference_rank`` ∈ 1..4), did NOT get it
+    here (``assignment == 0``), and is on a seatrade this block (``assigned_to_block``). This
+    surfaces near-misses — e.g. a same-preference group the solver split — without touching
+    Fleet Time blocks or unranked cells.
+    """
+    if preference_rank != UNMATCHED_PREFERENCE and assignment == 0 and assigned_to_block:
+        return str(preference_rank)
+    return ""
+
+
+def enrich_assignments_for_display(longform_df: pd.DataFrame) -> pd.DataFrame:
+    """Add the chart's display columns to a longform frame, without rendering anything.
+
+    The data layer carries only domain facts (``assignment``, ``preference_rank``,
+    ``assigned_to_block``); *where to paint ink* is a chart concern, extracted here as a pure
+    function so it is unit-testable without an Altair render. Adds:
+
+    - ``satisfaction`` — the colour bucket for an assigned cell (top pick → Unranked).
+    - ``rank_text`` — the bold rank printed on an assigned cell (blank for unranked).
+    - ``ghost_text`` — the faint rank printed on an unassigned-but-ranked, attended cell (else blank).
+    """
+    df = longform_df.copy()
+    df["satisfaction"] = df["preference_rank"].map(_satisfaction_label)
+    df["rank_text"] = df["preference_rank"].map(_rank_text)
+    df["ghost_text"] = df.apply(
+        lambda row: _ghost_text(row["preference_rank"], row["assignment"], row["assigned_to_block"]),
+        axis=1,
+    )
+    return df
+
+
 def display_fleet_assignments(fleet_grid: pd.DataFrame) -> alt.Chart:
     """Render the Cabin × Block fleet-placement overview as a neutral presence heatmap.
 
@@ -558,9 +592,8 @@ def display_assignments(solution: AssignmentSolution) -> alt.Chart:
         )
 
     longform_df = wrangle_assignments_to_longform(solution)
+    longform_df = enrich_assignments_for_display(longform_df)
     longform_df["block"] = longform_df["block"].map(block_label)
-    longform_df["satisfaction"] = longform_df["preference"].map(_satisfaction_label)
-    longform_df["rank_text"] = longform_df["preference"].map(_rank_text)
 
     assignment_base = alt.Chart(longform_df).encode(
         x=alt.X("seatrade", sort=solution.seatrades_full, title=None),
@@ -569,7 +602,9 @@ def display_assignments(solution: AssignmentSolution) -> alt.Chart:
     # Neutral fill behind every cell so the grid reads on a dark theme; assigned
     # cells are then coloured by satisfaction on top.
     assignment_background = assignment_base.mark_rect(color=UNASSIGNED_COLOR, stroke="white", strokeWidth=0.3)
-    assigned_cells = assignment_base.transform_filter(alt.datum.preference > 0)
+    # Filter on assignment == 1 (not the old preference > 0): unassigned cells now carry real
+    # ranks, so preference > 0 would mis-colour a ghost cell as a real placement.
+    assigned_cells = assignment_base.transform_filter(alt.datum.assignment == 1)
     assignment_rectangles = assigned_cells.mark_rect(stroke="black", strokeWidth=0.1).encode(
         color=alt.Color(
             "satisfaction:N",
@@ -578,8 +613,14 @@ def display_assignments(solution: AssignmentSolution) -> alt.Chart:
         )
     )
     assignment_text = assigned_cells.mark_text(color="black").encode(text="rank_text:N")
+    # Faint ghost ranks on unassigned-but-ranked cells the camper attends — a near-miss the
+    # solver couldn't satisfy. Same font as the bold rank, low opacity, over the untouched
+    # neutral background (no tint), so it never reads as a real placement. Opacity is the one
+    # tuning knob, set during visual verification.
+    ghost_cells = assignment_base.transform_filter(alt.datum.ghost_text != "")
+    assignment_ghost_text = ghost_cells.mark_text(color="black", opacity=0.3).encode(text="ghost_text:N")
     assignment_chart = (
-        (assignment_background + assignment_rectangles + assignment_text)
+        (assignment_background + assignment_rectangles + assignment_text + assignment_ghost_text)
         .facet(row="cabin", column="block", spacing={"row": 2})
         .resolve_scale(y="independent")
         .properties(

--- a/tests/test_app/conftest.py
+++ b/tests/test_app/conftest.py
@@ -58,7 +58,9 @@ def sample_mixed_assignment_df():
         "block": ["1a", "1a", "1a"],
         "seatrade": ["Archery", "Kayaking", "Archery"],
         "assignment": [1.0, 0.0, 1.0],
-        "preference": [1, 0, 1],
+        # preference_rank is carried on every cell (a pure camper↔seatrade fact), so the
+        # unassigned Kayaking row keeps its rank — no conflated 0.
+        "preference_rank": [1, 4, 1],
     }
     return pd.DataFrame(data)
 
@@ -76,6 +78,6 @@ def seatrade_sort_df():
         "block": ["2a", "1a", "1a", "1a"],
         "seatrade": ["Archery", "Archery", "Climbing", "Archery"],
         "assignment": [1.0, 1.0, 1.0, 1.0],
-        "preference": [1, 2, 1, 1],
+        "preference_rank": [1, 2, 1, 1],
     }
     return pd.DataFrame(data)

--- a/tests/test_app/test_assignments_done_view.py
+++ b/tests/test_app/test_assignments_done_view.py
@@ -102,6 +102,16 @@ class TestDoneView:
         assert log_areas, "solver log not shown in the done view"
         assert log_areas[0].value == at.session_state["solver_log"]
 
+    def test_master_grid_renders_with_the_preference_caption(self, solved_solution):
+        """After the longform schema change (issue #85), the master camper grid still renders
+        (the assigned layer's filter flipped to assignment == 1). Its single caption — emitted
+        right after the chart — decodes both the bold assigned ranks and the faint ghost numbers,
+        so its presence confirms display_assignments returned without raising on the new schema."""
+        at = _seed_done_view(solved_solution, success=True)
+
+        assert not at.exception
+        assert any("Numbers indicate camper-submitted seatrade preferences" in c.value for c in at.caption)
+
     def test_success_banner_shows_optimality_percent(self, solved_solution):
         """The green verdict banner carries the solver-optimality % inline; the donut itself
         moved down beside the Schedule Quality Overview."""

--- a/tests/test_seatrades/conftest.py
+++ b/tests/test_seatrades/conftest.py
@@ -65,7 +65,9 @@ def sample_mixed_assignment_df():
         "block": ["1a", "1a", "1a"],
         "seatrade": ["Archery", "Kayaking", "Archery"],
         "assignment": [1.0, 0.0, 1.0],
-        "preference": [1, 0, 1],
+        # preference_rank is a pure camper↔seatrade fact carried on every cell, so the
+        # unassigned Kayaking row still has the rank the camper gave it — no conflated 0.
+        "preference_rank": [1, 4, 1],
     }
     return pd.DataFrame(data)
 
@@ -82,7 +84,7 @@ def seatrade_sort_df():
         "block": ["2a", "1a", "1a", "1a"],
         "seatrade": ["Archery", "Archery", "Climbing", "Archery"],
         "assignment": [1.0, 1.0, 1.0, 1.0],
-        "preference": [1, 2, 1, 1],
+        "preference_rank": [1, 2, 1, 1],
     }
     return pd.DataFrame(data)
 

--- a/tests/test_seatrades/test_results.py
+++ b/tests/test_seatrades/test_results.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from seatrades.results import (
+    UNMATCHED_PREFERENCE,
     SolverState,
     SolverStatus,
     wrangle_assignments_to_longform,
@@ -123,18 +124,28 @@ class TestAssignmentSolution:
 class TestWrangleAssignmentsToLongform:
     def test_output_columns(self, sample_assignment_solution):
         result = wrangle_assignments_to_longform(sample_assignment_solution)
-        expected_cols = {"camper", "seatrade", "assignment", "preference", "cabin", "block"}
+        expected_cols = {"camper", "seatrade", "assignment", "preference_rank", "assigned_to_block", "cabin", "block"}
         assert expected_cols <= set(result.columns)
 
-    def test_assigned_rows_have_nonzero_preference(self, sample_assignment_solution):
+    def test_conflated_preference_column_is_gone(self, sample_assignment_solution):
+        # The old single ``preference`` column conflated unassigned/assigned/unranked. It is
+        # decomposed into assignment + preference_rank; leaving it would reintroduce the conflation.
+        result = wrangle_assignments_to_longform(sample_assignment_solution)
+        assert "preference" not in result.columns
+
+    def test_unassigned_ranked_cell_carries_its_rank(self, sample_assignment_solution):
+        # The core fix: an unassigned cell now records the rank the camper GAVE it, so a
+        # near-miss is recoverable. Alice (prefs Archery, Sailing, ...) got 1a_Archery, so
+        # her 1a_Sailing cell is unassigned but still carries rank 2.
+        result = wrangle_assignments_to_longform(sample_assignment_solution)
+        cell = result[(result["camper"] == "Alice") & (result["block"] == "1a") & (result["seatrade"] == "Sailing")]
+        assert cell["assignment"].item() == 0.0
+        assert cell["preference_rank"].item() == 2
+
+    def test_assigned_ranked_rows_carry_their_rank(self, sample_assignment_solution):
         result = wrangle_assignments_to_longform(sample_assignment_solution)
         assigned = result[result["assignment"] == 1.0]
-        assert (assigned["preference"] > 0).all()
-
-    def test_unassigned_rows_have_zero_preference(self, sample_assignment_solution):
-        result = wrangle_assignments_to_longform(sample_assignment_solution)
-        unassigned = result[result["assignment"] == 0.0]
-        assert (unassigned["preference"] == 0).all()
+        assert assigned["preference_rank"].isin([1, 2, 3, 4, UNMATCHED_PREFERENCE]).all()
 
     def test_cabin_lookup(self, sample_assignment_solution):
         result = wrangle_assignments_to_longform(sample_assignment_solution)
@@ -175,6 +186,70 @@ def fleet_split_solution(sample_assignment_solution):
         assignments=assignments,
         seatrades_full=seatrades_full,
     )
+
+
+@pytest.fixture
+def unranked_seatrade_solution(sample_assignment_solution):
+    """The sample plus a Diving offering nobody ranked — so cells for it carry the sentinel.
+
+    Every camper in the sample ranks all three *running* seatrades, so there are no unranked
+    cells to test. Diving is offered but on nobody's preference list — the assigned-but-unranked
+    (and unassigned-unranked) cell state.
+    """
+    assignments = sample_assignment_solution.assignments.copy()
+    assignments["1a_Diving"] = 0.0
+    seatrades_full = sample_assignment_solution.seatrades_full + ["1a_Diving"]
+    return dataclasses.replace(
+        sample_assignment_solution,
+        assignments=assignments,
+        seatrades_full=seatrades_full,
+    )
+
+
+class TestLongformScheduleAndPreferenceFacts:
+    """The decomposed cell facts: preference_rank (camper↔seatrade) vs assigned_to_block (schedule)."""
+
+    def _cell(self, result, camper, block, seatrade):
+        return result[
+            (result["camper"] == camper) & (result["block"] == block) & (result["seatrade"] == seatrade)
+        ].iloc[0]
+
+    def test_unranked_cell_carries_the_unmatched_sentinel(self, unranked_seatrade_solution):
+        # A cell for a seatrade the camper never ranked holds UNMATCHED_PREFERENCE (not 0) — the
+        # "unranked" state, kept off the display by the color/ghost filters, not by a zero rank.
+        result = wrangle_assignments_to_longform(unranked_seatrade_solution)
+        diving = result[result["seatrade"] == "Diving"]
+        assert (diving["preference_rank"] == UNMATCHED_PREFERENCE).all()
+
+    def test_ghost_rank_survives_in_the_campers_other_attended_block(self, sample_assignment_solution):
+        # Alice got Archery (her #1) in block 1a and Sailing in 2b. Her Archery rank must STILL
+        # surface in 2b — an unassigned, ranked cell in a block she attends — so a split same-pref
+        # group stays fully visible (show-even-if-fulfilled-elsewhere). This is the key decision.
+        result = wrangle_assignments_to_longform(sample_assignment_solution)
+        cell = self._cell(result, "Alice", "2b", "Archery")
+        assert cell["assignment"] == 0.0
+        assert cell["preference_rank"] == 1
+        assert bool(cell["assigned_to_block"]) is True
+
+    def test_assigned_to_block_true_where_camper_has_a_seatrade(self, fleet_split_solution):
+        # Cabin1's camper 0 is on Fleet 1: a seatrade in block 1a.
+        result = wrangle_assignments_to_longform(fleet_split_solution)
+        cell = self._cell(result, "Alice", "1a", "Archery")
+        assert bool(cell["assigned_to_block"]) is True
+
+    def test_assigned_to_block_false_in_a_fleet_time_block(self, fleet_split_solution):
+        # Camper 0 is on Fleet 1, so block 1b is Fleet Time for them — no seatrade that block.
+        result = wrangle_assignments_to_longform(fleet_split_solution)
+        block_1b = result[(result["camper"] == "Alice") & (result["block"] == "1b")]
+        assert (block_1b["assigned_to_block"] == False).all()  # noqa: E712
+
+    def test_preference_rank_populated_even_in_a_fleet_time_block(self, fleet_split_solution):
+        # preference_rank is a pure camper↔seatrade fact, so it is present even on a Fleet Time
+        # block's cells; assigned_to_block is what keeps a ghost from drawing there, not a blank rank.
+        result = wrangle_assignments_to_longform(fleet_split_solution)
+        cell = self._cell(result, "Alice", "1b", "Sailing")  # Alice ranks Sailing #2
+        assert cell["preference_rank"] == 2
+        assert bool(cell["assigned_to_block"]) is False
 
 
 class TestWrangleFleetAssignments:

--- a/tests/test_seatrades/test_visualization.py
+++ b/tests/test_seatrades/test_visualization.py
@@ -6,7 +6,7 @@ import json
 import pandas as pd
 import pytest
 
-from seatrades.results import SolverState, SolverStatus
+from seatrades.results import UNMATCHED_PREFERENCE, SolverState, SolverStatus
 from seatrades.scoring import score
 from seatrades.visualization import (
     _DETAIL_BUILDERS,
@@ -25,6 +25,7 @@ from seatrades.visualization import (
     display_quality_summary,
     display_seatrade_staffing,
     display_sparsity_detail,
+    enrich_assignments_for_display,
     metric_label,
     normalize_to_band,
 )
@@ -527,6 +528,51 @@ class TestNormalizeToBand:
         assert up_is_good == 25.0
 
 
+class TestEnrichAssignmentsForDisplay:
+    """The pure display-derivation seam: longform facts → satisfaction / rank_text / ghost_text.
+
+    Ghost text is drawn on a cell iff preference_rank ∈ 1..4 AND assignment == 0 AND
+    assigned_to_block — an unassigned seatrade the camper ranked, in a block they attend.
+    """
+
+    def _one_cell(self, assignment, preference_rank, assigned_to_block):
+        df = pd.DataFrame(
+            {
+                "assignment": [assignment],
+                "preference_rank": [preference_rank],
+                "assigned_to_block": [assigned_to_block],
+            }
+        )
+        return enrich_assignments_for_display(df).iloc[0]
+
+    def test_ghost_text_for_unassigned_ranked_attended_cell(self):
+        cell = self._one_cell(assignment=0.0, preference_rank=3, assigned_to_block=True)
+        assert cell["ghost_text"] == "3"
+
+    def test_no_ghost_text_when_assigned(self):
+        # An assigned cell shows its bold rank_text, never a ghost.
+        cell = self._one_cell(assignment=1.0, preference_rank=2, assigned_to_block=True)
+        assert cell["ghost_text"] == ""
+        assert cell["rank_text"] == "2"
+
+    def test_no_ghost_text_in_a_fleet_time_block(self):
+        # Not attending a seatrade this block (Fleet Time) → no ghost, keeping Fleet blocks blank.
+        cell = self._one_cell(assignment=0.0, preference_rank=3, assigned_to_block=False)
+        assert cell["ghost_text"] == ""
+
+    def test_no_ghost_text_for_an_unranked_cell(self):
+        # A seatrade the camper never ranked has no rank to ghost.
+        cell = self._one_cell(assignment=0.0, preference_rank=UNMATCHED_PREFERENCE, assigned_to_block=True)
+        assert cell["ghost_text"] == ""
+
+    def test_assigned_unranked_cell_reads_unranked_with_blank_text(self):
+        # Unchanged behavior: an assigned seatrade the camper never ranked buckets as "Unranked"
+        # with blank rank_text.
+        cell = self._one_cell(assignment=1.0, preference_rank=UNMATCHED_PREFERENCE, assigned_to_block=True)
+        assert cell["satisfaction"] == "Unranked"
+        assert cell["rank_text"] == ""
+
+
 class TestDisplayAssignmentsFailureGuard:
     def test_raises_on_infeasible_status(self, sample_assignment_solution):
         """display_assignments must raise ValueError when optimization was infeasible."""
@@ -598,6 +644,31 @@ class TestDisplayAssignmentsLegibility:
         """Block facet columns show compact labels (e.g. '1st·AM'), not raw codes alone."""
         spec = display_assignments(sample_assignment_solution).to_dict()
         assert "1st·AM" in json.dumps(spec, ensure_ascii=False)
+
+    def test_assigned_layer_filters_on_assignment_not_preference(self, sample_assignment_solution):
+        """The coloured/rank layers filter on assignment == 1, not the old preference > 0 — now
+        that unassigned cells carry real ranks, the old filter would mis-colour ghost cells."""
+        blob = json.dumps(display_assignments(sample_assignment_solution).to_dict())
+        assert "datum.assignment" in blob
+        assert "datum.preference" not in blob
+
+    def test_faint_ghost_text_layer_is_present(self, sample_assignment_solution):
+        """A distinct text layer prints ghost ranks faintly (reduced opacity) over the neutral
+        background, separate from the bold assigned rank_text layer."""
+        spec = display_assignments(sample_assignment_solution).to_dict()
+        text_layers = [layer for layer in spec["spec"]["layer"] if layer.get("mark", {}).get("type") == "text"]
+        ghost = [
+            layer for layer in text_layers if layer.get("encoding", {}).get("text", {}).get("field") == "ghost_text"
+        ]
+        assert ghost, "no ghost_text layer found"
+        assert ghost[0]["mark"]["opacity"] < 1.0
+
+    def test_ghost_ranks_are_computed_into_the_data(self, sample_assignment_solution):
+        """End-to-end: at least one cell carries a ghost rank (Alice ranked Sailing/Climbing but
+        got Archery in block 1a), so the layer has something to draw."""
+        spec = display_assignments(sample_assignment_solution).to_dict()
+        rows = spec["datasets"][spec["data"]["name"]] if "datasets" in spec else spec["data"]["values"]
+        assert any(row.get("ghost_text") for row in rows)
 
 
 class TestOptimalityDonut:

--- a/tests/test_seatrades/test_visualization.py
+++ b/tests/test_seatrades/test_visualization.py
@@ -13,6 +13,7 @@ from seatrades.visualization import (
     FLEET_STATE_RANGE,
     SATISFACTION_RANGE,
     STAFFING_STATE_RANGE,
+    add_display_columns,
     display_age_spread_detail,
     display_assignments,
     display_cohesion_detail,
@@ -25,7 +26,6 @@ from seatrades.visualization import (
     display_quality_summary,
     display_seatrade_staffing,
     display_sparsity_detail,
-    enrich_assignments_for_display,
     metric_label,
     normalize_to_band,
 )
@@ -543,7 +543,7 @@ class TestEnrichAssignmentsForDisplay:
                 "assigned_to_block": [assigned_to_block],
             }
         )
-        return enrich_assignments_for_display(df).iloc[0]
+        return add_display_columns(df).iloc[0]
 
     def test_ghost_text_for_unassigned_ranked_attended_cell(self):
         cell = self._one_cell(assignment=0.0, preference_rank=3, assigned_to_block=True)

--- a/tests/test_seatrades/test_wideform.py
+++ b/tests/test_seatrades/test_wideform.py
@@ -27,7 +27,7 @@ def longform_assigned():
             "block": "1a",
             "seatrade": "Archery",
             "assignment": 1.0,
-            "preference": 1,
+            "preference_rank": 1,
         },
         {
             "camper": "Alice",
@@ -36,7 +36,7 @@ def longform_assigned():
             "block": "2b",
             "seatrade": "Sailing",
             "assignment": 1.0,
-            "preference": 2,
+            "preference_rank": 2,
         },
         {
             "camper": "Bob",
@@ -45,7 +45,7 @@ def longform_assigned():
             "block": "1b",
             "seatrade": "Climbing",
             "assignment": 1.0,
-            "preference": 1,
+            "preference_rank": 1,
         },
         {
             "camper": "Bob",
@@ -54,7 +54,7 @@ def longform_assigned():
             "block": "2a",
             "seatrade": "Archery",
             "assignment": 1.0,
-            "preference": 3,
+            "preference_rank": 3,
         },
         # Cabin2 campers
         {
@@ -64,7 +64,7 @@ def longform_assigned():
             "block": "1a",
             "seatrade": "Sailing",
             "assignment": 1.0,
-            "preference": 1,
+            "preference_rank": 1,
         },
         {
             "camper": "Carol",
@@ -73,7 +73,7 @@ def longform_assigned():
             "block": "2b",
             "seatrade": "Archery",
             "assignment": 1.0,
-            "preference": 2,
+            "preference_rank": 2,
         },
         {
             "camper": "Dave",
@@ -82,7 +82,7 @@ def longform_assigned():
             "block": "1b",
             "seatrade": "Archery",
             "assignment": 1.0,
-            "preference": 1,
+            "preference_rank": 1,
         },
         {
             "camper": "Dave",
@@ -91,7 +91,7 @@ def longform_assigned():
             "block": "2a",
             "seatrade": "Sailing",
             "assignment": 1.0,
-            "preference": 2,
+            "preference_rank": 2,
         },
     ]
     return pd.DataFrame(rows)


### PR DESCRIPTION
Closes #85.

## What & why

On the master camper × seatrade grid, a Scheduling Captain could only see the preference rank for seatrades a camper **got**. The rank they gave a seatrade they **didn't** get was invisible — hiding near-misses (the motivating case: a same-preference group the solver splits 4-and-1).

This decomposes the conflated longform `preference` column into orthogonal facts and draws the "didn't get" rank **faintly** on the cells a camper ranked but wasn't assigned, in the blocks they actually attend a seatrade.

## Changes

**Data layer** (`results.py`, `wrangle_assignments_to_longform`) — replaces the single `preference` column (which conflated `0`=unassigned / `1–4`=assigned+ranked / `999`=assigned+unranked):
- `assignment` (0/1) — unchanged
- `preference_rank` — the rank the camper *gave* a seatrade (`1–4`, else `999`), on **every** cell → the "didn't get" rank is recoverable
- `assigned_to_block` (bool) — any seatrade this block vs Fleet Time (a schedule fact, distinct from `assignment`)

**Viz** (`visualization.py`):
- extract pure `enrich_assignments_for_display` (satisfaction / rank_text / ghost_text) — unit-testable without a render
- flip assigned filter `preference>0` → `assignment==1` (required: ghost cells now carry real ranks)
- faint ghost text layer, opacity `0.3`, over the untouched neutral background. Ghost rule: `rank ∈ 1..4 AND assignment==0 AND assigned_to_block`

**Callers** — `scoring.py` → `preference_rank`; app caption *"Numbers indicate camper-submitted seatrade preferences."*; test-fixture renames.

**Docs** — `CONTEXT.md` longform-columns glossary corrected; new [ADR 0010](docs/adr/0010-decompose-preference-into-orthogonal-facts.md) records the decomposition (don't re-collapse the columns "for simplicity").

## Cell states

| state | condition | rendering |
|---|---|---|
| assigned + ranked | `assignment==1`, `1..4` | colored cell + bold rank (unchanged) |
| assigned + unranked | `assignment==1`, `999` | "Unranked", blank text (unchanged) |
| unassigned + ranked + attended | `assignment==0`, `1..4`, `assigned_to_block` | **NEW** faint grey ghost rank |
| everything else | — | blank neutral cell (unchanged) |

## Testing
- `test_results.py` — four cell states, plus a ghost surviving in the camper's *other* attended block ("show even if fulfilled elsewhere") and absent in a Fleet Time block
- `test_visualization.py` — pure enrich seam (ghost rule), filter flip, faint layer present, ghosts computed into the data
- `test_assignments_done_view.py` — AppTest smoke: master grid renders after the filter flip + caption
- **452 passed** (fast) / **6 passed** (slow real-solve); ruff + mypy clean

## Not done here
Visual opacity legibility on the dark theme — the Playwright MCP was wedged this session. Per the PRD the `0.3` opacity is the one tuning knob and a visual detail, not a correctness gate; worth a quick eyeball before merge. The underlying ghost data was confirmed on a real CBC solve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)